### PR TITLE
Bug fixes related to removing inventories and impact areas

### DIFF
--- a/ViewModel/AggregatedStageDamage/AggregatedStageDamageEditorVM.cs
+++ b/ViewModel/AggregatedStageDamage/AggregatedStageDamageEditorVM.cs
@@ -218,6 +218,10 @@ namespace ViewModel.AggregatedStageDamage
                     int structID = CalculatedVM.SelectedStructures.GetElementID();
                     LastEditDate = DateTime.Now.ToString("G");
                     AggregatedStageDamageElement elem = new AggregatedStageDamageElement(Name, LastEditDate, Description, wseID, structID, ManualVM.GetStageDamageCurves(), true);
+                    if (CurrentElement == null)
+                    {
+                        CurrentElement = elem;
+                    }
                     CurrentElement.LastEditDate = LastEditDate;
                     Saving.PersistenceManagers.StageDamagePersistenceManager manager = Saving.PersistenceFactory.GetStageDamageManager();
                     manager.SaveNew(elem);

--- a/ViewModel/ImpactArea/ImpactAreaElement.cs
+++ b/ViewModel/ImpactArea/ImpactAreaElement.cs
@@ -103,7 +103,7 @@ namespace ViewModel.ImpactArea
         {
             DatabaseManager.SQLiteManager sqr = new DatabaseManager.SQLiteManager(Storage.Connection.Instance.ProjectFile);
             LifeSimGIS.GeoPackageReader gpr = new LifeSimGIS.GeoPackageReader(sqr);
-            string tableBaseName = ImpactAreaPersistenceManager.IndexPointTableNameConstant;
+            string tableBaseName = ImpactAreaPersistenceManager.IMPACT_AREA_TABLE_PREFIX;
             LifeSimGIS.PolygonFeatures polyFeatures = (LifeSimGIS.PolygonFeatures)gpr.ConvertToGisFeatures(tableBaseName + Name);
             LifeSimGIS.VectorFeatures features = polyFeatures;
             //read from table.

--- a/ViewModel/Saving/PersistenceManagers/StructureInventoryPersistenceManager.cs
+++ b/ViewModel/Saving/PersistenceManagers/StructureInventoryPersistenceManager.cs
@@ -199,6 +199,9 @@ namespace ViewModel.Saving.PersistenceManagers
         public void Remove(ChildElement element)
         {
             RemoveFromParentTable(element, TableName);
+            string inventoryTable = STRUCTURE_INVENTORY_TABLE_CONSTANT + element.Name;
+            RemoveTable(inventoryTable);
+            RemoveFromGeopackageTable(inventoryTable);
             StudyCacheForSaving.RemoveElement((InventoryElement)element);
 
         }

--- a/ViewModel/Saving/PersistenceManagers/TerrainElementPersistenceManager.cs
+++ b/ViewModel/Saving/PersistenceManagers/TerrainElementPersistenceManager.cs
@@ -98,9 +98,9 @@ namespace ViewModel.Saving.PersistenceManagers
             {
                 await Task.Run(() =>
                 {
-                    if (System.IO.File.Exists(element.FileName))//System.IO.File.Exists(Storage.Connection.Instance.TerrainDirectory + "\\" + element.Name))
+                    if (File.Exists(element.FileName))
                     {
-                        System.IO.File.Delete(element.FileName);//Storage.Connection.Instance.TerrainDirectory + "\\" + element.Name);
+                        File.Delete(element.FileName);
                     }
                 });
             }

--- a/ViewModel/Saving/PersistenceManagers/WaterSurfaceAreaPersistenceManager.cs
+++ b/ViewModel/Saving/PersistenceManagers/WaterSurfaceAreaPersistenceManager.cs
@@ -200,7 +200,7 @@ namespace ViewModel.Saving.PersistenceManagers
         public void Remove(ChildElement element)
         {
             RemoveFromParentTable(element, TableName);
-            Storage.Connection.Instance.DeleteTable(PathAndProbTableConstant + element.Name); 
+            RemoveTable(PathAndProbTableConstant + element.Name); 
             //if the wse was imported from old fda, then it won't have associated files.
             WaterSurfaceElevationElement elem = (WaterSurfaceElevationElement)element;
             if (elem.HasAssociatedFiles)

--- a/ViewModel/Saving/SavingBase.cs
+++ b/ViewModel/Saving/SavingBase.cs
@@ -101,11 +101,8 @@ namespace ViewModel.Saving
 
         public List<ChildElement> CreateElementsFromRows(string tableName, Func<object[], ChildElement> createElemsFromRowDataAction)
         {
+            OpenConnection();
             List<ChildElement> elems = new List<ChildElement>();
-            if (!Connection.Instance.IsOpen)
-            {
-                Connection.Instance.Open();
-            }
 
             DataTable table = Connection.Instance.GetDataTable(tableName);
             foreach (DataRow row in table.Rows)
@@ -155,10 +152,7 @@ namespace ViewModel.Saving
         #region save new
         public void SaveNewElement(ChildElement element)
         {
-            if (!Connection.Instance.IsOpen)
-            {
-                Connection.Instance.Open();
-            }
+            OpenConnection();
             //update the edit date
             string editDate = DateTime.Now.ToString("G");
             element.LastEditDate = editDate;
@@ -169,10 +163,7 @@ namespace ViewModel.Saving
         }
         public void SaveNewElementToParentTable(object[] rowData, string tableName, string[] TableColumnNames, Type[] TableColumnTypes)
         {
-            if (!Connection.Instance.IsOpen)
-            {
-                Connection.Instance.Open();
-            }
+            OpenConnection();
             DatabaseManager.DataTableView tbl = Connection.Instance.GetTable(tableName);
             if (tbl == null)
             {
@@ -185,10 +176,7 @@ namespace ViewModel.Saving
 
         public void SaveExisting(ChildElement oldElement, ChildElement elementToSave)
         {
-            if (!Connection.Instance.IsOpen)
-            {
-                Connection.Instance.Open();
-            }
+            OpenConnection();
             string editDate = DateTime.Now.ToString("G");
             elementToSave.LastEditDate = editDate;
 
@@ -202,15 +190,31 @@ namespace ViewModel.Saving
 
         #endregion
 
-        #region Remove element
-
-        public virtual void RemoveFromParentTable(ChildElement element, string tableName)
+        private void OpenConnection()
         {
-
             if (!Connection.Instance.IsOpen)
             {
                 Connection.Instance.Open();
             }
+        }
+
+        #region Remove element
+        public void RemoveTable(string tableName)
+        {
+            OpenConnection();
+            if (Connection.Instance.TableNames().Contains(tableName))
+            {
+                Connection.Instance.DeleteTable(tableName);                
+            }
+        }
+        public void RemoveFromGeopackageTable(string tableName)
+        {
+            LifeSimGIS.GeoPackageWriter gpw = new LifeSimGIS.GeoPackageWriter(Connection.Instance.Reader);
+            gpw.DeleteFeatures(tableName);
+        }
+        public virtual void RemoveFromParentTable(ChildElement element, string tableName)
+        {
+            OpenConnection();
 
             element.RemoveElementFromMapWindow(this, new EventArgs());
 
@@ -243,10 +247,7 @@ namespace ViewModel.Saving
         /// <param name="values">The values that you want in the columns listed in "columns"</param>
         public void UpdateTableRow(string tableName, int primaryKey, string primaryKeyColName, string[] columns, object[] values)
         {
-            if (!Connection.Instance.IsOpen)
-            {
-                Connection.Instance.Open();
-            }
+            OpenConnection();
             //columns and values need to be corespond to each other, you don't have to update columns that don't need it
             StringBuilder sb = new StringBuilder("update ").Append(tableName).Append(" set ");
             for(int i = 0;i<columns.Length;i++)
@@ -273,10 +274,7 @@ namespace ViewModel.Saving
         {
             //this sql query looks like this:
             //update occupancy_types set Name = 'codyistesting' where GroupID = 1 and OcctypeID = 1
-            if (!Connection.Instance.IsOpen)
-            {
-                Connection.Instance.Open();
-            }
+            OpenConnection();
             //columns and values need to be corespond to each other, you don't have to update columns that don't need it
             StringBuilder sb = new StringBuilder("update ").Append(tableName).Append(" set ");
             for (int i = 0; i < columns.Length; i++)
@@ -302,10 +300,7 @@ namespace ViewModel.Saving
         {
             //this sql query looks like this:
             //delete from occupancy_types where GroupID = 1 and OcctypeID = 27
-            if (!Connection.Instance.IsOpen)
-            {
-                Connection.Instance.Open();
-            }
+            OpenConnection();
             StringBuilder sb = new StringBuilder("delete from ").Append(tableName).Append(" where ");
             for (int i = 0; i < primaryKeys.Length; i++)
             {
@@ -323,10 +318,7 @@ namespace ViewModel.Saving
         {
             //this sql query looks like this:
             //delete from occupancy_types where GroupID = 1
-            if (!Connection.Instance.IsOpen)
-            {
-                Connection.Instance.Open();
-            }
+            OpenConnection();
             //if the table doesn't exist, then there is nothing to delete
             if(Connection.Instance.GetTable(tableName) == null)
             {


### PR DESCRIPTION
 Bug fixes. The structure inventories were not being removed properly when deleting the child element. When investigating, other elements were also not deleting correctly. I added logic to delete the secondary table in the database and delete the geo package reference to the table in the geo package tables.