### PR TITLE
Feature/sample from grids

### DIFF
--- a/Fda.sln
+++ b/Fda.sln
@@ -30,7 +30,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HEC.FDA.Model", "fda-model\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fda-model-cmd", "fda-model-cmd\fda-model-cmd.csproj", "{074FDF94-DCFA-4229-8784-E743B852087F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fda-model-test", "fda-model-test\fda-model-test.csproj", "{2D770541-506D-472B-BCA3-F9286AFB517D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HEC.FDA.ModelTest", "fda-model-test\HEC.FDA.ModelTest.csproj", "{2D770541-506D-472B-BCA3-F9286AFB517D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Statistics", "Statistics\Statistics.csproj", "{647DC29F-872B-4F2E-AA4F-D6E014EA42C9}"
 EndProject

--- a/Fda.sln
+++ b/Fda.sln
@@ -28,7 +28,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HEC.FDA.ViewModelTest", "HE
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HEC.FDA.Model", "fda-model\HEC.FDA.Model.csproj", "{E68C672B-2C87-4039-88F3-71D0D6E1DE9A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fda-model-cmd", "fda-model-cmd\fda-model-cmd.csproj", "{074FDF94-DCFA-4229-8784-E743B852087F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HEC.FDA.ModelCmd", "fda-model-cmd\HEC.FDA.ModelCmd.csproj", "{074FDF94-DCFA-4229-8784-E743B852087F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HEC.FDA.ModelTest", "fda-model-test\HEC.FDA.ModelTest.csproj", "{2D770541-506D-472B-BCA3-F9286AFB517D}"
 EndProject

--- a/HEC.FDA.ViewModelTest/HEC.FDA.ViewModelTest.csproj
+++ b/HEC.FDA.ViewModelTest/HEC.FDA.ViewModelTest.csproj
@@ -28,8 +28,8 @@
 	<ItemGroup>
 		<!--Even though GDAL Assist is available as a transative dependency through Ras.Mapper, it needs
 		to be directly referenced as well to ensure GDAL is copied into the output directory.-->
-		<PackageReference Include="Geospatial.GDALAssist" Version="1.0.21-beta-g2e34768d8b" />
-		<PackageReference Include="Ras.Mapper" Version="1.0.21-beta-g2e34768d8b" />
+		<PackageReference Include="Geospatial.GDALAssist" Version="1.0.24-beta-gf5955b1108" />
+		<PackageReference Include="Ras.Mapper" Version="1.0.24-beta-gf5955b1108" />
 	</ItemGroup>
 	
 </Project>

--- a/ViewModel/HEC.FDA.ViewModel.csproj
+++ b/ViewModel/HEC.FDA.ViewModel.csproj
@@ -34,8 +34,8 @@
 	<ItemGroup>
 		<!--Even though GDAL Assist is available as a transative dependency through Ras.Mapper, it needs
 		to be directly referenced as well to ensure GDAL is copied into the output directory.-->
-		<PackageReference Include="Geospatial.GDALAssist" Version="1.0.21-beta-g2e34768d8b" />
-		<PackageReference Include="Ras.Mapper" Version="1.0.21-beta-g2e34768d8b" />
+		<PackageReference Include="Geospatial.GDALAssist" Version="1.0.24-beta-gf5955b1108" />
+		<PackageReference Include="Ras.Mapper" Version="1.0.24-beta-gf5955b1108" />
 	</ItemGroup>
 
 </Project>

--- a/fda-model-cmd/HEC.FDA.ModelCmd.csproj
+++ b/fda-model-cmd/HEC.FDA.ModelCmd.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
-		<RootNamespace>fda_model_cmd</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/fda-model-test/HEC.FDA.ModelTest.csproj
+++ b/fda-model-test/HEC.FDA.ModelTest.csproj
@@ -22,8 +22,8 @@
 	<ItemGroup>
 		<!--Even though GDAL Assist is available as a transative dependency through Ras.Mapper, it needs
 		to be directly referenced as well to ensure GDAL is copied into the output directory.-->
-		<PackageReference Include="Geospatial.GDALAssist" Version="1.0.21-beta-g2e34768d8b" />
-		<PackageReference Include="Ras.Mapper" Version="1.0.21-beta-g2e34768d8b" />
+		<PackageReference Include="Geospatial.GDALAssist" Version="1.0.24-beta-gf5955b1108" />
+		<PackageReference Include="Ras.Mapper" Version="1.0.24-beta-gf5955b1108" />
 	</ItemGroup>
 
 </Project>

--- a/fda-model-test/HEC.FDA.ModelTest.csproj
+++ b/fda-model-test/HEC.FDA.ModelTest.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<RootNamespace>fda_model_test</RootNamespace>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 

--- a/fda-model-test/integrationtests/DefaultDataComputeOutcomes.cs
+++ b/fda-model-test/integrationtests/DefaultDataComputeOutcomes.cs
@@ -10,7 +10,7 @@ using Statistics.Distributions;
 using Statistics.Histograms;
 using Xunit;
 
-namespace fda_model_test.integrationtests
+namespace HEC.FDA.ModelTest.integrationtests
 {
     public class DefaultDataComputeOutcomes
     {
@@ -42,7 +42,7 @@ namespace fda_model_test.integrationtests
         private static RandomProvider randomProvider = new RandomProvider(seed);
         //set up exterior-interior relationship 
 
-        private static double[] _ExteriorInteriorXValues = new double[] {927, 928, 930, 931, 932, 933, 934, 935, 935.5, 936, 936.5, 937, 937.5, 938, 950 };
+        private static double[] _ExteriorInteriorXValues = new double[] { 927, 928, 930, 931, 932, 933, 934, 935, 935.5, 936, 936.5, 937, 937.5, 938, 950 };
         private static IDistribution[] _ExteriorInteriorYValues = new IDistribution[]
         {
             new Deterministic(927),
@@ -146,7 +146,7 @@ namespace fda_model_test.integrationtests
             double[] mostLIkely = new double[] { 929.21, 931.4, 932.6, 933.6, 934.5, 935.2, 935.8, 936.5, 937.1, 937.6, 938.6, 939.7, 940.7, 941.6, 942.1, 943.2, 944.6 };
             double[] minStages = new double[] { 928.9, 930.7, 932, 933, 933.8, 934.5, 935, 935.4, 935.9, 936.3, 937.1, 937.9, 938.6, 939.3, 941.2, 942.3, 944.5 };
             double[] maxStages = new double[] { 929.5, 931.9, 933.3, 934.4, 935.3, 936.1, 936.8, 937.6, 938.2, 939, 940.2, 941.4, 942.8, 943.8, 944.25, 946.6, 948.5 };
-            IDistribution[] stageDischarge = new IDistribution[mostLIkely.Length];  
+            IDistribution[] stageDischarge = new IDistribution[mostLIkely.Length];
             for (int i = 0; i < mostLIkely.Length; i++)
             {
                 stageDischarge[i] = new Triangular(minStages[i], mostLIkely[i], maxStages[i]);
@@ -173,10 +173,10 @@ namespace fda_model_test.integrationtests
         private static UncertainPairedData systemResponse = new UncertainPairedData(_FailureXValues, _FailureYValues, failureLeveeMetaData);
         private static double defaultLeveeElevation = 937;
         private static double[] defaultFailureStages = new double[] { 920, 936.999, 937, 948 };
-        private static IDistribution[] defaultFailureProbs = new IDistribution[] 
-        { 
-            new Deterministic(0), 
-            new Deterministic(0), 
+        private static IDistribution[] defaultFailureProbs = new IDistribution[]
+        {
+            new Deterministic(0),
+            new Deterministic(0),
             new Deterministic(1),
             new Deterministic(1),
         };
@@ -189,7 +189,7 @@ namespace fda_model_test.integrationtests
         #endregion
 
         [Theory]
-        [InlineData(310937.1,295506.53 )]
+        [InlineData(310937.1, 295506.53)]
         public void WithoutAnalytical_ScenarioResults(double expectedCommercialMeanEAD, double expectedResidentialMeanEAD)
         {
             //Arrange 
@@ -211,11 +211,11 @@ namespace fda_model_test.integrationtests
             //Act
             double actualCommercialMeanEAD = scenarioResults.MeanExpectedAnnualConsequences(impactAreaID1, commercialDamageCategory);
             double actualResidentialMeanEAD = scenarioResults.MeanExpectedAnnualConsequences(impactAreaID1, residentialDamageCategory);
-            double actualMeanAAEQ = alternativeResults.MeanAAEQDamage(impactAreaID1,commercialDamageCategory);
+            double actualMeanAAEQ = alternativeResults.MeanAAEQDamage(impactAreaID1, commercialDamageCategory);
             double actualCommercialMeanEADFromAnotherSource = eadHistogram.Mean;
             double tolerance = 0.11;
             double strictTolerance = 0.01;
-            double commercialMeanEADSourcesRelativeDifference = Math.Abs(actualCommercialMeanEAD - actualCommercialMeanEADFromAnotherSource)/actualCommercialMeanEADFromAnotherSource;
+            double commercialMeanEADSourcesRelativeDifference = Math.Abs(actualCommercialMeanEAD - actualCommercialMeanEADFromAnotherSource) / actualCommercialMeanEADFromAnotherSource;
             double commercialEADRelativeDifference = Math.Abs(actualCommercialMeanEAD - expectedCommercialMeanEAD) / expectedCommercialMeanEAD;
             double residentialEADRelativeDifference = Math.Abs(actualResidentialMeanEAD - expectedResidentialMeanEAD) / expectedResidentialMeanEAD;
             double AAEQRelativeDifference = Math.Abs(actualMeanAAEQ - expectedCommercialMeanEAD) / expectedCommercialMeanEAD; //EAD is constant over POA soq AAEQ = EAD
@@ -252,7 +252,7 @@ namespace fda_model_test.integrationtests
             ScenarioResults scenarioResults = scenario.Compute(randomProvider, convergenceCriteria);
 
             //Act
-            double actualResidentialMeanEAD = scenarioResults.MeanExpectedAnnualConsequences(impactAreaID1,residentialDamageCategory);
+            double actualResidentialMeanEAD = scenarioResults.MeanExpectedAnnualConsequences(impactAreaID1, residentialDamageCategory);
             double actualCommercialMeanEAD = scenarioResults.MeanExpectedAnnualConsequences(impactAreaID1, commercialDamageCategory);
             double tolerance = 0.19;
             double residentialEADRelativeDifference = Math.Abs(actualResidentialMeanEAD - expectedResidentialMeanEAD) / expectedResidentialMeanEAD;
@@ -419,7 +419,7 @@ namespace fda_model_test.integrationtests
         //    ImpactAreaScenarioResults impactAreaScenarioResults = scenarioResults.GetResults(impactAreaID1);
 
         //    bool resultsAreNull = impactAreaScenarioResults.ConsequenceResults.ConsequenceResultList.Count == 0;
-            
+
         //    Assert.True(resultsAreNull);
 
         //}

--- a/fda-model-test/integrationtests/DesPeresStudyDataTests.cs
+++ b/fda-model-test/integrationtests/DesPeresStudyDataTests.cs
@@ -6,7 +6,7 @@ using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.compute;
 using HEC.FDA.Model.metrics;
 
-namespace fda_model_test.integrationtests
+namespace HEC.FDA.ModelTest.integrationtests
 {
     public class DesPeresStudyDataTests
     {
@@ -14,7 +14,7 @@ namespace fda_model_test.integrationtests
         static int erl = 50;
         static double[] exceedanceProabilities = new double[] { .5, .2, .1, .04, .02, .01, .005, .002 };
         static double[] stagesForFrequency = new double[] { .001, .002, .003, .004, .005, .006, .007, .553 };
-        static CurveMetaData metaDataDefault = new CurveMetaData("x","y","res","struct");
+        static CurveMetaData metaDataDefault = new CurveMetaData("x", "y", "res", "struct");
         static GraphicalUncertainPairedData graphicalUncertain = new GraphicalUncertainPairedData(exceedanceProabilities, stagesForFrequency, erl, metaDataDefault);
         static double[] stagesForDamage = new double[] { 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2, 2.1 };
 
@@ -63,4 +63,3 @@ namespace fda_model_test.integrationtests
         }
     }
 }
- 

--- a/fda-model-test/integrationtests/GraphicalUncertaintyShould.cs
+++ b/fda-model-test/integrationtests/GraphicalUncertaintyShould.cs
@@ -9,7 +9,7 @@ using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.interfaces;
 using HEC.FDA.Model.compute;
 
-namespace fda_model_test.integrationtests
+namespace HEC.FDA.ModelTest.integrationtests
 {
     public class GraphicalUncertaintyShould
     {
@@ -20,9 +20,9 @@ namespace fda_model_test.integrationtests
         [InlineData(new double[] { .99, .5, .2, .1, .04, .02, .01, .004, .002 }, new double[] { 480, 481, 482, 483, 486, 488, 490, 494, 496 }, 50, .98, true, new double[] { 482.734, 485.367, 490.633, 493.266 })]
         [InlineData(new double[] { .99, .5, .2, .1, .04, .02, .01, .004, .002 }, new double[] { 480, 481, 482, 483, 486, 488, 490, 494, 496 }, 50, .998, true, new double[] { 488.361, 492.18, 499.82, 503.639 })]
         [InlineData(new double[] { .99, .5, .2, .1, .04, .02, .01, .004, .002 }, new double[] { 480, 481, 482, 483, 486, 488, 490, 494, 496 }, 12, .9, true, new double[] { 480.969, 481.638, 484.675, 486.35 })]
-        [InlineData(new double[] { .99, .5, .2, .1, .04, .02, .01, .004, .002 }, new double[] { 480, 481, 482, 483, 486, 488, 490, 494, 496 }, 12, .95, true, new double[] {480.97, 481.638, 489.264, 493.205  })]
-        [InlineData(new double[] { .99, .5, .2, .1, .04, .02, .01, .004, .002 }, new double[] { 480, 481, 482, 483, 486, 488, 490, 494, 496 }, 12, .98, true, new double[] {480.97, 482.625, 493.375, 498.750 })]
-        [InlineData(new double[] { .99, .5, .2, .1, .04, .02, .01, .004, .002 }, new double[] { 480, 481, 482, 483, 486, 488, 490, 494, 496 }, 12, .998, true, new double[] {480.973, 488.203, 503.797, 511.593 })]
+        [InlineData(new double[] { .99, .5, .2, .1, .04, .02, .01, .004, .002 }, new double[] { 480, 481, 482, 483, 486, 488, 490, 494, 496 }, 12, .95, true, new double[] { 480.97, 481.638, 489.264, 493.205 })]
+        [InlineData(new double[] { .99, .5, .2, .1, .04, .02, .01, .004, .002 }, new double[] { 480, 481, 482, 483, 486, 488, 490, 494, 496 }, 12, .98, true, new double[] { 480.97, 482.625, 493.375, 498.750 })]
+        [InlineData(new double[] { .99, .5, .2, .1, .04, .02, .01, .004, .002 }, new double[] { 480, 481, 482, 483, 486, 488, 490, 494, 496 }, 12, .998, true, new double[] { 480.973, 488.203, 503.797, 511.593 })]
         //[InlineData(new double[] {.99, .5, .2, .1, .04, .02, .01, .004, .002 }, new double[] { 1, 1.5, 2, 3, 5, 9, 12, 16, 19}, 50, .9, true, new double[] {1.727, 2.333, 3.667, 4.335 })]
         //[InlineData(new double[] { .99, .5, .2, .1, .04, .02, .01, .004, .002 }, new double[] { 1, 1.5, 2, 3, 5, 9, 12, 16, 19 }, 50, .95, true, new double[] {1.975, 3.262, 5.836, 7.123  })]
         //[InlineData(new double[] { .99, .5, .2, .1, .04, .02, .01, .004, .002 }, new double[] { 1, 1.5, 2, 3, 5, 9, 12, 16, 19 }, 50, .98, true, new double[] { 1.975, 4.297, 13.703, 18.406 })]
@@ -47,9 +47,9 @@ namespace fda_model_test.integrationtests
             double binWidth = (int)(range / quantityOfBins);
             ThreadsafeInlineHistogram graphicalThreadsafeInlineHistogram = new ThreadsafeInlineHistogram(binWidth, convergenceCriteria);
             int masterseed = 1234;
-            Int64 progressChunks = 1;
-            Int64 _completedIterations = 0;
-            Int64 _ExpectedIterations = convergenceCriteria.MaxIterations;
+            long progressChunks = 1;
+            long _completedIterations = 0;
+            long _ExpectedIterations = convergenceCriteria.MaxIterations;
             if (_ExpectedIterations > 100)
             {
                 progressChunks = _ExpectedIterations / 100;
@@ -60,10 +60,10 @@ namespace fda_model_test.integrationtests
             {
                 seeds[i] = masterSeedList.Next();
             }
-            Int64 iterations = convergenceCriteria.MinIterations;
+            long iterations = convergenceCriteria.MinIterations;
             double lowerQuantile = 0.025;
             double upperQuantile = 0.975;
-            
+
             while (!graphicalThreadsafeInlineHistogram.IsHistogramConverged(upperQuantile, lowerQuantile))
             {
                 Parallel.For(0, iterations, i =>
@@ -91,7 +91,7 @@ namespace fda_model_test.integrationtests
                 double actualStageOrFlow = graphicalThreadsafeInlineHistogram.InverseCDF(percentiles[j]);
                 double expectedStageOrFlow = expectedFlowsOrStages[j];
                 double difference = actualStageOrFlow - expectedStageOrFlow;
-                double error = (actualStageOrFlow - expectedStageOrFlow)/expectedStageOrFlow;
+                double error = (actualStageOrFlow - expectedStageOrFlow) / expectedStageOrFlow;
                 Debug.WriteLine("| {0,9} | {1,25} | {2,-19} | {3,-17} | {4, -18}| {5, -18}|", 1 - nonExceedanceProbability, percentiles[j], expectedStageOrFlow, actualStageOrFlow, difference, error);
             }
         }

--- a/fda-model-test/integrationtests/StudyDataAnalyticalFrequencyResultsTests.cs
+++ b/fda-model-test/integrationtests/StudyDataAnalyticalFrequencyResultsTests.cs
@@ -7,9 +7,9 @@ using HEC.FDA.Model.metrics;
 using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.compute;
 
-namespace fda_model_test
+namespace HEC.FDA.ModelTest.integrationtests
 {
-    [Trait("Category","Integration")]
+    [Trait("Category", "Integration")]
     public class StudyDataAnalyticalFrequencyResultsTests
     {
 
@@ -44,7 +44,7 @@ namespace fda_model_test
             new Normal(477.4,.5)
                 //note that the rating curve domain lies within the stage-damage domain
         };
-        static double[] StageDamageStages = {460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479 };
+        static double[] StageDamageStages = { 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479 };
         static IDistribution[] DamageDistrbutions =
         {
             new Normal(0,0),
@@ -88,7 +88,7 @@ namespace fda_model_test
         [InlineData(20.74)]
         public void ComputeMeanEAD_Test(double expected)
         {
-            Statistics.ContinuousDistribution flowFrequency = new Statistics.Distributions.LogPearson3(3.537, .438, .075, 125);
+            ContinuousDistribution flowFrequency = new LogPearson3(3.537, .438, .075, 125);
             UncertainPairedData flowStage = new UncertainPairedData(RatingCurveFlows, StageDistributions, metaData);
             UncertainPairedData stageDamage = new UncertainPairedData(StageDamageStages, DamageDistrbutions, metaData);
             List<UncertainPairedData> stageDamageList = new List<UncertainPairedData>();
@@ -99,7 +99,7 @@ namespace fda_model_test
                 .withStageDamages(stageDamageList)
                 .build();
             ImpactAreaScenarioResults results = simulation.PreviewCompute();
-            double difference = expected - results.ConsequenceResults.MeanDamage(damCat,assetCat,impactAreaID);
+            double difference = expected - results.ConsequenceResults.MeanDamage(damCat, assetCat, impactAreaID);
             double relativeDifference = difference / expected;
             Assert.True(relativeDifference < .016);
         }
@@ -110,10 +110,10 @@ namespace fda_model_test
         /// <param name="seed"></param>
         /// <param name="expected"></param>
         [Theory]
-        [InlineData(10000,2345,21.09)]
+        [InlineData(10000, 2345, 21.09)]
         public void ComputeMeanEADWithIterations_Test(int iterations, int seed, double expected)
         {
-            Statistics.ContinuousDistribution flowFrequency = new Statistics.Distributions.LogPearson3(3.537, .438, .075, 125);
+            ContinuousDistribution flowFrequency = new LogPearson3(3.537, .438, .075, 125);
             UncertainPairedData flowStage = new UncertainPairedData(RatingCurveFlows, StageDistributions, metaData);
             UncertainPairedData stageDamage = new UncertainPairedData(StageDamageStages, DamageDistrbutions, metaData);
             List<UncertainPairedData> stageDamageList = new List<UncertainPairedData>();
@@ -127,7 +127,7 @@ namespace fda_model_test
             RandomProvider randomProvider = new RandomProvider(seed);
             ConvergenceCriteria cc = new ConvergenceCriteria(minIterations: 100, maxIterations: iterations);
             ImpactAreaScenarioResults results = simulation.Compute(randomProvider, cc);
-            double difference = expected - results.ConsequenceResults.MeanDamage(damCat,assetCat,impactAreaID);
+            double difference = expected - results.ConsequenceResults.MeanDamage(damCat, assetCat, impactAreaID);
             double relativeDifference = Math.Abs(difference / expected);
             Assert.True(relativeDifference < .015);
         }
@@ -143,7 +143,7 @@ namespace fda_model_test
         [InlineData(10000, 2345, 19.46, 475, .2487)]
         public void ComputeMeanEADAndPerformanceWithIterationsAndLevee_Test(int iterations, int seed, double expectedEAD, double topOfLeveeElevation, double meanExpectedAEP)
         {
-            Statistics.ContinuousDistribution flowFrequency = new Statistics.Distributions.LogPearson3(3.537, .438, .075, 125);
+            ContinuousDistribution flowFrequency = new LogPearson3(3.537, .438, .075, 125);
             UncertainPairedData flowStage = new UncertainPairedData(RatingCurveFlows, StageDistributions, metaData);
             UncertainPairedData stageDamage = new UncertainPairedData(StageDamageStages, DamageDistrbutions, metaData);
             List<UncertainPairedData> stageDamageList = new List<UncertainPairedData>();
@@ -154,22 +154,22 @@ namespace fda_model_test
             IDistribution[] leveefailprobs = new IDistribution[3];
             for (int i = 0; i < 2; i++)
             {
-                leveefailprobs[i] = new Statistics.Distributions.Deterministic(0); //probability at the top must be 1
+                leveefailprobs[i] = new Deterministic(0); //probability at the top must be 1
             }
-            leveefailprobs[2] = new Statistics.Distributions.Deterministic(1);
+            leveefailprobs[2] = new Deterministic(1);
             UncertainPairedData leveeFragilityFunction = new UncertainPairedData(leveestages, leveefailprobs, metaData);
 
             ImpactAreaScenarioSimulation simulation = ImpactAreaScenarioSimulation.builder(impactAreaID)
                 .withFlowFrequency(flowFrequency)
                 .withFlowStage(flowStage)
                 .withStageDamages(stageDamageList)
-                .withLevee(leveeFragilityFunction,topOfLeveeElevation)
+                .withLevee(leveeFragilityFunction, topOfLeveeElevation)
                 .build();
             RandomProvider randomProvider = new RandomProvider(seed);
             ConvergenceCriteria cc = new ConvergenceCriteria(minIterations: 1000, maxIterations: iterations);
             ImpactAreaScenarioResults results = simulation.Compute(randomProvider, cc);
 
-            double differenceEAD = expectedEAD - results.ConsequenceResults.MeanDamage(damCat,assetCat,impactAreaID);
+            double differenceEAD = expectedEAD - results.ConsequenceResults.MeanDamage(damCat, assetCat, impactAreaID);
             double relativeDifferenceEAD = Math.Abs(differenceEAD / expectedEAD);
             Assert.True(relativeDifferenceEAD < .02);
             SystemPerformanceResults systemPerformanceResults = results.PerformanceByThresholds.GetThreshold(0).SystemPerformanceResults;
@@ -188,9 +188,9 @@ namespace fda_model_test
         [InlineData(10000, 2345, 20.63, 475, .4225)]
         public void ComputeMeanEADAndPerformanceWithIterationsAndLeveeAndFragility_Test(int iterations, int seed, double expectedEAD, double topOfLeveeElevation, double meanExpectedAEP)
         {
-            Statistics.ContinuousDistribution flowFrequency = new Statistics.Distributions.LogPearson3(3.537, .438, .075, 125);
+            ContinuousDistribution flowFrequency = new LogPearson3(3.537, .438, .075, 125);
             UncertainPairedData flowStage = new UncertainPairedData(RatingCurveFlows, StageDistributions, metaData);
-            UncertainPairedData stageDamage = new UncertainPairedData(StageDamageStages, DamageDistrbutions,metaData);
+            UncertainPairedData stageDamage = new UncertainPairedData(StageDamageStages, DamageDistrbutions, metaData);
             List<UncertainPairedData> stageDamageList = new List<UncertainPairedData>();
             stageDamageList.Add(stageDamage);
             UncertainPairedData fragilityCurve = new UncertainPairedData(FragilityStages, FragilityProbabilities, xLabel, yLabel, name);
@@ -204,7 +204,7 @@ namespace fda_model_test
             ConvergenceCriteria cc = new ConvergenceCriteria(minIterations: 100, maxIterations: iterations);
             ImpactAreaScenarioResults results = simulation.Compute(randomProvider, cc);
 
-            double differenceEAD = expectedEAD - results.ConsequenceResults.MeanDamage(damCat,assetCat,impactAreaID);
+            double differenceEAD = expectedEAD - results.ConsequenceResults.MeanDamage(damCat, assetCat, impactAreaID);
             double relativeDifferenceEAD = Math.Abs(differenceEAD / expectedEAD);
             Assert.True(relativeDifferenceEAD < .01);//try assert.equal with -2
             SystemPerformanceResults systemPerformanceResults = results.PerformanceByThresholds.GetThreshold(0).SystemPerformanceResults;

--- a/fda-model-test/integrationtests/StudyDataGraphicalFlowFrequencyResultsTests.cs
+++ b/fda-model-test/integrationtests/StudyDataGraphicalFlowFrequencyResultsTests.cs
@@ -7,7 +7,7 @@ using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.compute;
 using HEC.FDA.Model.metrics;
 
-namespace fda_model_test.integrationtests
+namespace HEC.FDA.ModelTest.integrationtests
 {
     /// <summary>
     /// The example data in this test is based on Bear Creek Workshop 4 FDA study data
@@ -63,8 +63,8 @@ namespace fda_model_test.integrationtests
         static string assetCat = "content";
         static int impactAreaID = 0;
         static CurveTypesEnum curveType = CurveTypesEnum.StrictlyMonotonicallyIncreasing;
-        static CurveMetaData curveMetaData = new CurveMetaData(xLabel, yLabel, name, damCat, curveType,assetCat);
-        
+        static CurveMetaData curveMetaData = new CurveMetaData(xLabel, yLabel, name, damCat, curveType, assetCat);
+
         [Theory]
         [InlineData(1234, 0.96)]
         public void ComputeMeanEADWithIterations_Test(int seed, double expected)
@@ -81,13 +81,13 @@ namespace fda_model_test.integrationtests
                 .build();
             RandomProvider randomProvider = new RandomProvider(seed);
             ConvergenceCriteria convergenceCriteria = new ConvergenceCriteria();
-            ImpactAreaScenarioResults results = simulation.Compute(randomProvider,convergenceCriteria);
-            double difference = Math.Abs(expected - results.ConsequenceResults.MeanDamage(damCat,assetCat,impactAreaID));
+            ImpactAreaScenarioResults results = simulation.Compute(randomProvider, convergenceCriteria);
+            double difference = Math.Abs(expected - results.ConsequenceResults.MeanDamage(damCat, assetCat, impactAreaID));
             double relativeDifference = difference / expected;
             double tolerance = 0.05;
             Assert.True(relativeDifference < tolerance);
         }
-        
+
 
     }
 }

--- a/fda-model-test/integrationtests/StudyDataGraphicalStageFrequencyResultsTests.cs
+++ b/fda-model-test/integrationtests/StudyDataGraphicalStageFrequencyResultsTests.cs
@@ -7,7 +7,7 @@ using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.compute;
 using HEC.FDA.Model.metrics;
 
-namespace fda_model_test.integrationtests
+namespace HEC.FDA.ModelTest.integrationtests
 {
     /// <summary>
     /// The example data in this test is based on River Des Peres study data
@@ -19,7 +19,7 @@ namespace fda_model_test.integrationtests
         static int equivalentRecordLength = 25;
         static double[] exceedanceProbabilities = new double[] { .5, .2, .1, .04, .02, .01, .005, .002 };
         static double[] stageFrequencyStages = new double[] { 370, 373, 378, 381, 384, 385, 386, 387 };
-       
+
         static double[] stageDamageStages = new double[] { 369.5, 370, 370.5, 371, 371.5, 372, 372.5, 373, 373.5, 374, 374.5, 375, 375.5, 376, 376.5, 377, 377.5, 378, 378.5, 379, 379.5, 380, 380.5, 381, 381.5, 382, 382.5, 383, 383.5, 384, 384.5, 385, 385.5, 386, 386.5, 387, 387.5, 388, 388.5, 389, 389.5, 390, 390.5, 391, 391.5, 392, 392.5, 393, 393.5, 394, 394.5, 395 };
         static IDistribution[] stageDamageDamageDistributions = new IDistribution[]
         {
@@ -83,7 +83,7 @@ namespace fda_model_test.integrationtests
         static string category = "residential";
         static CurveTypesEnum curveType = CurveTypesEnum.StrictlyMonotonicallyIncreasing;
         static CurveMetaData curveMetaData = new CurveMetaData(xLabel, yLabel, name, category, curveType, assetcategory);
-        
+
         [Theory]
         [InlineData(1234, 5.88)]
         public void ComputeMeanEADWithIterations_Test(int seed, double expected)
@@ -98,13 +98,13 @@ namespace fda_model_test.integrationtests
                 .build();
             RandomProvider randomProvider = new RandomProvider(seed);
             ConvergenceCriteria convergenceCriteria = new ConvergenceCriteria();
-            ImpactAreaScenarioResults results = simulation.Compute(randomProvider,convergenceCriteria);
+            ImpactAreaScenarioResults results = simulation.Compute(randomProvider, convergenceCriteria);
             double difference = Math.Abs(expected - results.MeanExpectedAnnualConsequences(impactareaid, category, assetcategory));
             double relativeDifference = difference / expected;
             double tolerance = 0.05;
             Assert.True(relativeDifference < tolerance);
         }
-        
+
 
     }
 }

--- a/fda-model-test/integrationtests/dbftests.cs
+++ b/fda-model-test/integrationtests/dbftests.cs
@@ -1,7 +1,7 @@
 ﻿using Xunit;
 using HEC.FDA.Model.utilities;
 
-namespace fda_model_test.integrationtests
+namespace HEC.FDA.ModelTest.integrationtests
 {
     [Trait("Category", "Integration")]
     public class dbftests
@@ -11,11 +11,11 @@ namespace fda_model_test.integrationtests
         {
             string filepath = @"..\\..\\Resources\\ProbData.dbf";
             dbfreader dbr = new dbfreader(filepath);
-            double mean = (double)dbr.GetCell("LOG_MEAN",0);
+            double mean = (double)dbr.GetCell("LOG_MEAN", 0);
             Assert.Equal(2.944761, mean);
-            double stdev = (double)dbr.GetCell("STD_DEV",0);
+            double stdev = (double)dbr.GetCell("STD_DEV", 0);
             Assert.Equal(0.256108, stdev);
-            double skew = (double)dbr.GetCell("SKEW",0);
+            double skew = (double)dbr.GetCell("SKEW", 0);
             Assert.Equal(0.2409, skew);
         }
     }

--- a/fda-model-test/unittests/AlternativeComparisonReportTests.cs
+++ b/fda-model-test/unittests/AlternativeComparisonReportTests.cs
@@ -10,7 +10,7 @@ using HEC.FDA.Model.scenarios;
 using HEC.FDA.Model.alternativeComparisonReport;
 using HEC.FDA.Model.alternatives;
 
-namespace fda_model_test.unittests
+namespace HEC.FDA.ModelTest.unittests
 {
     [Trait("Category", "Unit")]
     public class AlternativeComparisonReportTest
@@ -312,7 +312,7 @@ namespace fda_model_test.unittests
             }
             Assert.True(testPasses);
         }
-        
+
         [Theory]
         [InlineData(51442, 36500, 75000, 50, .0275, 2023, 2072, 1, 75000)]
         [InlineData(59410, 36500, 75000, 50, .0275, 2023, 2050, 1, 75000)]

--- a/fda-model-test/unittests/AlternativeTest.cs
+++ b/fda-model-test/unittests/AlternativeTest.cs
@@ -9,7 +9,7 @@ using HEC.FDA.Model.compute;
 using HEC.FDA.Model.scenarios;
 using HEC.FDA.Model.alternatives;
 
-namespace fda_model_test.unittests
+namespace HEC.FDA.ModelTest.unittests
 {
     [Trait("Category", "Unit")]
     public class AlternativeTest
@@ -33,16 +33,16 @@ namespace fda_model_test.unittests
         [InlineData(239260.1814, 239260.1814, 150000, 300000, 150000, 300000, 50, .0275, 2023, 2050, 1)]
         public void AlternativeResults_Test(double expectedAAEQDamageExceededWithAnyProbability, double expectedMeanAAEQ, double expectedBaseYearEAD, double expectedFutureYearEAD, double expectedBaseYearDamageExceededWithAnyProb, double expectedFutureYearDamageExceededWithAnyProb, int poa, double discountRate, int baseYear, int futureYear, int iterations)
         {
-                MedianRandomProvider meanRandomProvider = new MedianRandomProvider();
-                ConvergenceCriteria convergenceCriteria = new ConvergenceCriteria(minIterations: iterations, maxIterations: iterations);
-                ContinuousDistribution flow_frequency = new Uniform(0, 100000, 1000);
-                //create a stage distribution
-                IDistribution[] stages = new IDistribution[2];
-                for (int i = 0; i < 2; i++)
-                {
-                    stages[i] = new Uniform(0, 300000 * i, 10);
-                }
-                UncertainPairedData flow_stage = new UncertainPairedData(FlowXs, stages, metaData);
+            MedianRandomProvider meanRandomProvider = new MedianRandomProvider();
+            ConvergenceCriteria convergenceCriteria = new ConvergenceCriteria(minIterations: iterations, maxIterations: iterations);
+            ContinuousDistribution flow_frequency = new Uniform(0, 100000, 1000);
+            //create a stage distribution
+            IDistribution[] stages = new IDistribution[2];
+            for (int i = 0; i < 2; i++)
+            {
+                stages[i] = new Uniform(0, 300000 * i, 10);
+            }
+            UncertainPairedData flow_stage = new UncertainPairedData(FlowXs, stages, metaData);
             //create a damage distribution for base and future year (future year assumption is massive economic development) 
             IDistribution[] baseDamages = new IDistribution[3]
             {
@@ -56,68 +56,68 @@ namespace fda_model_test.unittests
                     new Uniform(0,1200000,10),
                     new Uniform(0,1200000, 10)
             };
-                UncertainPairedData base_stage_damage = new UncertainPairedData(StageXs, baseDamages, metaData);
-                UncertainPairedData future_stage_damage = new UncertainPairedData(StageXs, futureDamages, metaData);
-                List<UncertainPairedData> updBase = new List<UncertainPairedData>();
-                updBase.Add(base_stage_damage);
-                List<UncertainPairedData> updFuture = new List<UncertainPairedData>();
-                updFuture.Add(future_stage_damage);
+            UncertainPairedData base_stage_damage = new UncertainPairedData(StageXs, baseDamages, metaData);
+            UncertainPairedData future_stage_damage = new UncertainPairedData(StageXs, futureDamages, metaData);
+            List<UncertainPairedData> updBase = new List<UncertainPairedData>();
+            updBase.Add(base_stage_damage);
+            List<UncertainPairedData> updFuture = new List<UncertainPairedData>();
+            updFuture.Add(future_stage_damage);
 
-                ImpactAreaScenarioSimulation sBase = ImpactAreaScenarioSimulation.builder(impactAreaID)
-                    .withFlowFrequency(flow_frequency)
-                    .withFlowStage(flow_stage)
-                    .withStageDamages(updBase)
-                    .build();
+            ImpactAreaScenarioSimulation sBase = ImpactAreaScenarioSimulation.builder(impactAreaID)
+                .withFlowFrequency(flow_frequency)
+                .withFlowStage(flow_stage)
+                .withStageDamages(updBase)
+                .build();
 
-                ImpactAreaScenarioSimulation sFuture = ImpactAreaScenarioSimulation.builder(impactAreaID)
-                    .withFlowFrequency(flow_frequency)
-                    .withFlowStage(flow_stage)
-                    .withStageDamages(updFuture)
-                    .build();
+            ImpactAreaScenarioSimulation sFuture = ImpactAreaScenarioSimulation.builder(impactAreaID)
+                .withFlowFrequency(flow_frequency)
+                .withFlowStage(flow_stage)
+                .withStageDamages(updFuture)
+                .build();
 
-                IList<ImpactAreaScenarioSimulation> impactAreaListBaseYear = new List<ImpactAreaScenarioSimulation>();
-                impactAreaListBaseYear.Add(sBase);
-                IList<ImpactAreaScenarioSimulation> impactAreaListFutureYear = new List<ImpactAreaScenarioSimulation>();
-                impactAreaListFutureYear.Add(sFuture);
+            IList<ImpactAreaScenarioSimulation> impactAreaListBaseYear = new List<ImpactAreaScenarioSimulation>();
+            impactAreaListBaseYear.Add(sBase);
+            IList<ImpactAreaScenarioSimulation> impactAreaListFutureYear = new List<ImpactAreaScenarioSimulation>();
+            impactAreaListFutureYear.Add(sFuture);
 
-                Scenario baseScenario = new Scenario(baseYear, impactAreaListBaseYear);
-                ScenarioResults baseScenarioResults = baseScenario.Compute(meanRandomProvider, convergenceCriteria);
-                Scenario futureScenario = new Scenario(futureYear, impactAreaListFutureYear);
-                ScenarioResults futureScenarioResults = futureScenario.Compute(meanRandomProvider, convergenceCriteria);
+            Scenario baseScenario = new Scenario(baseYear, impactAreaListBaseYear);
+            ScenarioResults baseScenarioResults = baseScenario.Compute(meanRandomProvider, convergenceCriteria);
+            Scenario futureScenario = new Scenario(futureYear, impactAreaListFutureYear);
+            ScenarioResults futureScenarioResults = futureScenario.Compute(meanRandomProvider, convergenceCriteria);
 
-                AlternativeResults alternativeResults = new Alternative().AnnualizationCompute(meanRandomProvider, discountRate, poa, alternativeID, baseScenarioResults, futureScenarioResults);
-                double tolerance = 0.05;
+            AlternativeResults alternativeResults = new Alternative().AnnualizationCompute(meanRandomProvider, discountRate, poa, alternativeID, baseScenarioResults, futureScenarioResults);
+            double tolerance = 0.05;
 
-                double actualAAEQExceededWithProb = alternativeResults.AAEQDamageExceededWithProbabilityQ(exceedanceProbability, impactAreaID, damCat, assetCat);
-                double differenceAAEQExceededWithProb = actualAAEQExceededWithProb - expectedAAEQDamageExceededWithAnyProbability;
-                double errorAAEQExceededWithProb = Math.Abs(differenceAAEQExceededWithProb / actualAAEQExceededWithProb);
-                Assert.True(errorAAEQExceededWithProb < tolerance);
+            double actualAAEQExceededWithProb = alternativeResults.AAEQDamageExceededWithProbabilityQ(exceedanceProbability, impactAreaID, damCat, assetCat);
+            double differenceAAEQExceededWithProb = actualAAEQExceededWithProb - expectedAAEQDamageExceededWithAnyProbability;
+            double errorAAEQExceededWithProb = Math.Abs(differenceAAEQExceededWithProb / actualAAEQExceededWithProb);
+            Assert.True(errorAAEQExceededWithProb < tolerance);
 
-                double actualMeanAAEQ = alternativeResults.MeanAAEQDamage(impactAreaID, damCat, assetCat);
-                double differenceAAEQMean = actualMeanAAEQ - expectedMeanAAEQ;
-                double errorMeanAAEQ = Math.Abs(differenceAAEQMean / actualMeanAAEQ);
-                Assert.True(errorMeanAAEQ < tolerance);
+            double actualMeanAAEQ = alternativeResults.MeanAAEQDamage(impactAreaID, damCat, assetCat);
+            double differenceAAEQMean = actualMeanAAEQ - expectedMeanAAEQ;
+            double errorMeanAAEQ = Math.Abs(differenceAAEQMean / actualMeanAAEQ);
+            Assert.True(errorMeanAAEQ < tolerance);
 
-                double actualBaseYearEAD = alternativeResults.MeanBaseYearEAD(impactAreaID, damCat, assetCat);
-                double differenceActualBaseYearEAD = actualBaseYearEAD - expectedBaseYearEAD;
-                double errorBaseYearEAD = Math.Abs(differenceActualBaseYearEAD / actualBaseYearEAD);
-                Assert.True(errorBaseYearEAD < tolerance);
+            double actualBaseYearEAD = alternativeResults.MeanBaseYearEAD(impactAreaID, damCat, assetCat);
+            double differenceActualBaseYearEAD = actualBaseYearEAD - expectedBaseYearEAD;
+            double errorBaseYearEAD = Math.Abs(differenceActualBaseYearEAD / actualBaseYearEAD);
+            Assert.True(errorBaseYearEAD < tolerance);
 
-                double actualFutureYearEAD = alternativeResults.MeanFutureYearEAD(impactAreaID, damCat, assetCat);
-                double differenceActualFutureYearEAD = actualFutureYearEAD - expectedFutureYearEAD;
-                double errorFutureYearEAD = Math.Abs(differenceActualFutureYearEAD / actualFutureYearEAD);
-                Assert.True(errorFutureYearEAD < tolerance);
+            double actualFutureYearEAD = alternativeResults.MeanFutureYearEAD(impactAreaID, damCat, assetCat);
+            double differenceActualFutureYearEAD = actualFutureYearEAD - expectedFutureYearEAD;
+            double errorFutureYearEAD = Math.Abs(differenceActualFutureYearEAD / actualFutureYearEAD);
+            Assert.True(errorFutureYearEAD < tolerance);
 
-                double actualBaseYearEADExceeded = alternativeResults.BaseYearEADDamageExceededWithProbabilityQ(exceedanceProbability, impactAreaID, damCat, assetCat);
-                double differenceActualBaseYearEADExceeded = actualBaseYearEADExceeded - expectedBaseYearDamageExceededWithAnyProb;
-                double errorBaseYearEADExceeded = Math.Abs(differenceActualBaseYearEADExceeded / actualBaseYearEADExceeded);
-                Assert.True(errorBaseYearEADExceeded < tolerance);
+            double actualBaseYearEADExceeded = alternativeResults.BaseYearEADDamageExceededWithProbabilityQ(exceedanceProbability, impactAreaID, damCat, assetCat);
+            double differenceActualBaseYearEADExceeded = actualBaseYearEADExceeded - expectedBaseYearDamageExceededWithAnyProb;
+            double errorBaseYearEADExceeded = Math.Abs(differenceActualBaseYearEADExceeded / actualBaseYearEADExceeded);
+            Assert.True(errorBaseYearEADExceeded < tolerance);
 
-                double actualFutureYearEADExceeded = alternativeResults.FutureYearEADDamageExceededWithProbabilityQ(exceedanceProbability, impactAreaID, damCat, assetCat);
-                double differenceActualFutureYearEADExceeded = actualFutureYearEADExceeded - expectedFutureYearDamageExceededWithAnyProb;
-                double errorFutureYearEADExceeded = Math.Abs(differenceActualFutureYearEADExceeded / actualFutureYearEADExceeded);
-                Assert.True(errorFutureYearEADExceeded < tolerance);
-        
+            double actualFutureYearEADExceeded = alternativeResults.FutureYearEADDamageExceededWithProbabilityQ(exceedanceProbability, impactAreaID, damCat, assetCat);
+            double differenceActualFutureYearEADExceeded = actualFutureYearEADExceeded - expectedFutureYearDamageExceededWithAnyProb;
+            double errorFutureYearEADExceeded = Math.Abs(differenceActualFutureYearEADExceeded / actualFutureYearEADExceeded);
+            Assert.True(errorFutureYearEADExceeded < tolerance);
+
         }
 
         [Theory]

--- a/fda-model-test/unittests/ConsequenceDistributionResultsShould.cs
+++ b/fda-model-test/unittests/ConsequenceDistributionResultsShould.cs
@@ -7,7 +7,7 @@ using Statistics.Histograms;
 using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.metrics;
 
-namespace unittests
+namespace HEC.FDA.ModelTest.unittests
 {
     public class ConsequenceDistributionResultsShould
     {
@@ -50,7 +50,7 @@ namespace unittests
             double actualMeanFirstUPDMiddleStage = uncertainPairedData[0].Yvals[9].InverseCDF(0.5);
             double actualMeanLastUPDLastStage = uncertainPairedData[3].SamplePairedData(0.5).f(19);
             double relativeErrorMeanFirstUPDMiddleStage = Math.Abs(actualMeanFirstUPDMiddleStage - expectedMeanAllOver) / expectedMeanAllOver;
-            double relativeErrorMeanLastUPDLastStage = Math.Abs(actualMeanLastUPDLastStage - expectedMeanAllOver)/expectedMeanAllOver;
+            double relativeErrorMeanLastUPDLastStage = Math.Abs(actualMeanLastUPDLastStage - expectedMeanAllOver) / expectedMeanAllOver;
             double tolerance = 0.5;
 
             //Assert

--- a/fda-model-test/unittests/ExpectedAnnualDamageResultsShould.cs
+++ b/fda-model-test/unittests/ExpectedAnnualDamageResultsShould.cs
@@ -7,7 +7,7 @@ using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.compute;
 using HEC.FDA.Model.metrics;
 
-namespace fda_model_test.unittests
+namespace HEC.FDA.ModelTest.unittests
 {
     public class ExpectedAnnualDamageResultsShould
     {//TODO: Access the requisite logic through Scenario results 
@@ -20,7 +20,7 @@ namespace fda_model_test.unittests
         static string assetCat = "content";
         static int id = 0;
         static CurveTypesEnum curveTypesEnum = CurveTypesEnum.StrictlyMonotonicallyIncreasing;
-        static CurveMetaData curveMetaDataWithCategory = new CurveMetaData(xLabel, yLabel, name, damCat, curveTypesEnum,assetCat);
+        static CurveMetaData curveMetaDataWithCategory = new CurveMetaData(xLabel, yLabel, name, damCat, curveTypesEnum, assetCat);
         static CurveMetaData curveMetaDataWithoutCategory = new CurveMetaData(xLabel, yLabel, name, curveTypesEnum);
 
         [Theory]

--- a/fda-model-test/unittests/GraphicalUncertaintyPairedDataTests.cs
+++ b/fda-model-test/unittests/GraphicalUncertaintyPairedDataTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 using System.Xml.Linq;
 using HEC.FDA.Model.paireddata;
 
-namespace fda_model_test.unittests
+namespace HEC.FDA.ModelTest.unittests
 {
     [Trait("Category", "Unit")]
     public class GraphicalUncertaintyPairedDataTests
@@ -33,7 +33,7 @@ namespace fda_model_test.unittests
             {
                 for (int j = 1; j < pairedData.Xvals.Length; j++)
                 {
-                    if (pairedData.Yvals[j] < pairedData.Yvals[j-1])
+                    if (pairedData.Yvals[j] < pairedData.Yvals[j - 1])
                     {
                         pass = false;
                         break;
@@ -41,7 +41,7 @@ namespace fda_model_test.unittests
                 }
                 Assert.True(pass);
             }
-           
+
         }
 
         [Theory]

--- a/fda-model-test/unittests/ImpactAreaScenarioResultsShould.cs
+++ b/fda-model-test/unittests/ImpactAreaScenarioResultsShould.cs
@@ -6,7 +6,7 @@ using HEC.FDA.Model.metrics;
 using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.compute;
 
-namespace fda_model_test.unittests
+namespace HEC.FDA.ModelTest.unittests
 {
     [Trait("Category", "Unit")]
 
@@ -25,7 +25,7 @@ namespace fda_model_test.unittests
         public void ResultsShouldReadTheSameStuffItWrites()
         {
             ConvergenceCriteria convergenceCriteria = new ConvergenceCriteria(minIterations: 1, maxIterations: 1);
-            Statistics.ContinuousDistribution flow_frequency = new Statistics.Distributions.Uniform(0, 100000, 1000);
+            ContinuousDistribution flow_frequency = new Statistics.Distributions.Uniform(0, 100000, 1000);
             //create a stage distribution
             IDistribution[] stages = new IDistribution[2];
             for (int i = 0; i < 2; i++)
@@ -63,7 +63,7 @@ namespace fda_model_test.unittests
         public void ResultsShouldNotComputeWhenMaxIterationsAreGreaterThanMinIterations()
         {
             ConvergenceCriteria convergenceCriteria = new ConvergenceCriteria(maxIterations: 1);
-            Statistics.ContinuousDistribution flow_frequency = new Statistics.Distributions.Uniform(0, 100000, 1000);
+            ContinuousDistribution flow_frequency = new Statistics.Distributions.Uniform(0, 100000, 1000);
             //create a stage distribution
             IDistribution[] stages = new IDistribution[2];
             for (int i = 0; i < 2; i++)

--- a/fda-model-test/unittests/MessagingTests/ImpactAreaScenarioSimulationShould.cs
+++ b/fda-model-test/unittests/MessagingTests/ImpactAreaScenarioSimulationShould.cs
@@ -1,5 +1,4 @@
-﻿using fda_model_test.unittests.MessagingTests;
-using HEC.FDA.Model.compute;
+﻿using HEC.FDA.Model.compute;
 using HEC.FDA.Model.metrics;
 using HEC.FDA.Model.paireddata;
 using HEC.MVVMFramework.Base.Implementations;
@@ -9,7 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Xunit;
 
-namespace fda_model_test.unittests
+namespace HEC.FDA.ModelTest.unittests.MessagingTests
 {
     public class ImpactAreaScenarioSimulationShould
     {
@@ -78,7 +77,7 @@ namespace fda_model_test.unittests
                 .build();
             RandomProvider randomProvider = new RandomProvider(seed);
             ConvergenceCriteria convergenceCriteria = new ConvergenceCriteria();
-            
+
 
             Listener listener = new Listener();
             MessageHub.Register(simulation);

--- a/fda-model-test/unittests/MessagingTests/Listener.cs
+++ b/fda-model-test/unittests/MessagingTests/Listener.cs
@@ -1,12 +1,10 @@
-﻿
-
-using HEC.MVVMFramework.Base.Enumerations;
+﻿using HEC.MVVMFramework.Base.Enumerations;
 using HEC.MVVMFramework.Base.Events;
 using HEC.MVVMFramework.Base.Interfaces;
 using System;
 using System.Collections.Generic;
 
-namespace fda_model_test.unittests.MessagingTests
+namespace HEC.FDA.ModelTest.unittests.MessagingTests
 {
     internal class Listener : IRecieveMessages
     {
@@ -24,11 +22,11 @@ namespace fda_model_test.unittests.MessagingTests
         public string GetMessageLogAsString()
         {
             List<string> messages = new List<string>();
-            foreach(var message in MessageLog)
+            foreach (var message in MessageLog)
             {
                 messages.Add(message.ToString());
             }
-            string messagesAsOneString = String.Join(Environment.NewLine, messages.ToArray());
+            string messagesAsOneString = string.Join(Environment.NewLine, messages.ToArray());
             return messagesAsOneString;
         }
     }

--- a/fda-model-test/unittests/PairedDataShould.cs
+++ b/fda-model-test/unittests/PairedDataShould.cs
@@ -1,7 +1,7 @@
 using Xunit;
 using HEC.FDA.Model.paireddata;
 
-namespace fda_model_test.unittests
+namespace HEC.FDA.ModelTest.unittests
 {
     [Trait("Category", "Unit")]
     public class PairedDataShould
@@ -16,7 +16,7 @@ namespace fda_model_test.unittests
         [InlineData(10, 6)]
         [InlineData(2, 0)]
         [InlineData(8, 4)]
-        [InlineData(7,3.5)]
+        [InlineData(7, 3.5)]
         [InlineData(3.5, 1.75)]
         public void ReturnYGivenX(double expected, double sample)
         {
@@ -24,7 +24,7 @@ namespace fda_model_test.unittests
             double actual = pairedMultiplyByTwo.f(sample);
             Assert.Equal(expected, actual);
         }
-        
+
         [Theory]
         [InlineData(3, 1.5)]
         [InlineData(10, 5)]
@@ -43,11 +43,11 @@ namespace fda_model_test.unittests
         public void Compose()
         {
             double[] countByTens = { 10, 20, 30, 40, 50 };
-            PairedData PairedByOnesAndTens = new PairedData(countByTens,countByOnes);
+            PairedData PairedByOnesAndTens = new PairedData(countByTens, countByOnes);
 
             IPairedData expected = PairedByOnesAndTens;
             IPairedData actual = pairedCountbyOnes.compose(PairedByOnesAndTens);
-            Assert.Equal(expected.Xvals,actual.Xvals);
+            Assert.Equal(expected.Xvals, actual.Xvals);
             Assert.Equal(expected.Yvals, actual.Yvals);
         }
 
@@ -90,11 +90,11 @@ namespace fda_model_test.unittests
             double[] multiplierXs = { 2, 3, 4 };
             double[] multiplierYs = { .5, .5, .5 };
             double[] expectedXs = { 1, 1.999, 2, 3, 4, 4.001, 5 };
-            double[] expectedYs = {0, 0, 1, 1.5, 2, 4.001, 5};
+            double[] expectedYs = { 0, 0, 1, 1.5, 2, 4.001, 5 };
             PairedData multiplier = new PairedData(multiplierXs, multiplierYs);
 
             PairedData expected = new PairedData(expectedXs, expectedYs);
-            PairedData actual = (PairedData)pairedCountbyOnes.multiply(multiplier); 
+            PairedData actual = (PairedData)pairedCountbyOnes.multiply(multiplier);
             Assert.Equal(expected.Xvals, actual.Xvals);
             Assert.Equal(expected.Yvals, actual.Yvals);
         }

--- a/fda-model-test/unittests/PerformanceTest.cs
+++ b/fda-model-test/unittests/PerformanceTest.cs
@@ -8,7 +8,7 @@ using HEC.FDA.Model.metrics;
 using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.compute;
 
-namespace fda_model_test.unittests
+namespace HEC.FDA.ModelTest.unittests
 {
     [Trait("Category", "Unit")]
     public class PerformanceTest
@@ -40,7 +40,7 @@ namespace fda_model_test.unittests
         [InlineData(9800, 20, 1, .02, 0.332392028244906)]
         public void ComputePerformanceWithSimulation_Test(double thresholdValue, int years, int iterations, double expectedAEP, double expectedLTEP)
         {
-            
+
             ContinuousDistribution flow_frequency = new Uniform(0, 100000, 1000);
             //create a stage distribution
             IDistribution[] stages = new IDistribution[2];
@@ -69,12 +69,12 @@ namespace fda_model_test.unittests
                 .withStageDamages(uncertainPairedDataList)
                 .withAdditionalThreshold(threshold)
                 .build();
- 
-            MedianRandomProvider meanRandomProvider = new MedianRandomProvider();
-            ImpactAreaScenarioResults results = simulation.Compute(meanRandomProvider, cc,false);
 
-            double actualAEP = results.MeanAEP(thresholdID); 
-            double actualLTEP = results.LongTermExceedanceProbability(thresholdID, years); 
+            MedianRandomProvider meanRandomProvider = new MedianRandomProvider();
+            ImpactAreaScenarioResults results = simulation.Compute(meanRandomProvider, cc, false);
+
+            double actualAEP = results.MeanAEP(thresholdID);
+            double actualLTEP = results.LongTermExceedanceProbability(thresholdID, years);
 
             double aepDifference = Math.Abs(expectedAEP - actualAEP);
             double aepRelativeDifference = aepDifference / expectedAEP;
@@ -92,7 +92,7 @@ namespace fda_model_test.unittests
         /// <param name="iterations"></param>
         /// <param name="expected"></param>
         [Theory]
-        [InlineData(9980, 1, .026)]  
+        [InlineData(9980, 1, .026)]
         public void ComputeLeveeAEP_Test(double thresholdValue, int iterations, double expected)
         {
             ContinuousDistribution flow_frequency = new Uniform(0, 100000, 1000);
@@ -119,13 +119,13 @@ namespace fda_model_test.unittests
                 .withFlowFrequency(flow_frequency)
                 .withFlowStage(flow_stage)
                 .withAdditionalThreshold(threshold)
-                .withLevee(leveeCurve,thresholdValue)
+                .withLevee(leveeCurve, thresholdValue)
                 .build();
 
             MedianRandomProvider meanRandomProvider = new MedianRandomProvider();
             ImpactAreaScenarioResults results = simulation.Compute(meanRandomProvider, cc, false);
             double actual = results.MeanAEP(thresholdID);
-            Assert.Equal(expected,actual,2);
+            Assert.Equal(expected, actual, 2);
         }
         /// <summary>
         /// calculations for the below test can be found at https://docs.google.com/spreadsheets/d/1ui_sPDAleoYyu-T3fgraY5ye-WAMVs_j/edit?usp=sharing&ouid=105470256128470573157&rtpof=true&sd=true
@@ -191,13 +191,13 @@ namespace fda_model_test.unittests
 
         [Fact]
         public void ConvergenceTest()
-        {            
+        {
             ConvergenceCriteria convergenceCriteria = new ConvergenceCriteria();
             ThresholdEnum thresholdType = ThresholdEnum.ExteriorStage;
             double thresholdValue = 4.1;
             int thresholdID1 = 1;
             int thresholdID2 = 2;
-            Threshold threshold1 = new Threshold(thresholdID1, convergenceCriteria, thresholdType,thresholdValue);
+            Threshold threshold1 = new Threshold(thresholdID1, convergenceCriteria, thresholdType, thresholdValue);
             Threshold threshold2 = new Threshold(thresholdID2, convergenceCriteria, thresholdType, thresholdValue);
             PerformanceByThresholds performanceByThresholds = new PerformanceByThresholds();
             performanceByThresholds.AddThreshold(threshold1);
@@ -211,11 +211,11 @@ namespace fda_model_test.unittests
             Random random = new Random(seed);
             Normal normal = new Normal();
 
-            for (int i = 0; i < convergenceCriteria.MinIterations/2; i++)
+            for (int i = 0; i < convergenceCriteria.MinIterations / 2; i++)
             {
-                double uniformObservation1 = random.NextDouble()+1;
-                double uniformObservation2 = random.NextDouble()+2;
-                double messyObservation = normal.InverseCDF(random.NextDouble())* random.NextDouble(); //+ random.NextDouble() * random.NextDouble() * random.NextDouble() * 1000;
+                double uniformObservation1 = random.NextDouble() + 1;
+                double uniformObservation2 = random.NextDouble() + 2;
+                double messyObservation = normal.InverseCDF(random.NextDouble()) * random.NextDouble(); //+ random.NextDouble() * random.NextDouble() * random.NextDouble() * 1000;
                 double messyObservationLogged = Math.Log(Math.Abs(messyObservation));
                 performanceByThresholds.GetThreshold(thresholdID1).SystemPerformanceResults.AddStageForAssurance(keyForCNEP, uniformObservation1, i);
                 performanceByThresholds.GetThreshold(thresholdID1).SystemPerformanceResults.AddStageForAssurance(keyForCNEP, uniformObservation2, i);
@@ -225,7 +225,7 @@ namespace fda_model_test.unittests
             ImpactAreaScenarioResults results = new ImpactAreaScenarioResults(id);
             results.PerformanceByThresholds = performanceByThresholds;
 
-            bool isFirstThresholdConverged = performanceByThresholds.GetThreshold(thresholdID1).SystemPerformanceResults.AssuranceTestForConvergence(.05,.95);
+            bool isFirstThresholdConverged = performanceByThresholds.GetThreshold(thresholdID1).SystemPerformanceResults.AssuranceTestForConvergence(.05, .95);
             bool isSecondThresholdConverged = performanceByThresholds.GetThreshold(thresholdID2).SystemPerformanceResults.AssuranceTestForConvergence(.05, .95);
             bool isPerformanceConverged = results.IsPerformanceConverged();
 

--- a/fda-model-test/unittests/ScenarioShould.cs
+++ b/fda-model-test/unittests/ScenarioShould.cs
@@ -8,7 +8,7 @@ using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.compute;
 using HEC.FDA.Model.scenarios;
 
-namespace fda_model_test.unittests
+namespace HEC.FDA.ModelTest.unittests
 {
     public class ScenarioShould
     {

--- a/fda-model-test/unittests/StageDamageShould.cs
+++ b/fda-model-test/unittests/StageDamageShould.cs
@@ -10,11 +10,11 @@ using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.compute;
 using HEC.FDA.Model.metrics;
 
-namespace fda_model_test.unittests
+namespace HEC.FDA.ModelTest.unittests
 {
     public class StageDamageShould
     {
-    
+
         //structure data
         private static int[] structureIDs = new int[] { 0, 1, 2, 3, };
         private static PointM pointM = new PointM();
@@ -94,7 +94,7 @@ namespace fda_model_test.unittests
             }
             List<OccupancyType> occupancyTypesList = new List<OccupancyType>() { residentialOccupancyType, commercialOccupancyType };
             Inventory inventory = new Inventory(structures, occupancyTypesList);
-            float[] WSEs = new float[] {7, 10, 8, 12 };
+            float[] WSEs = new float[] { 7, 10, 8, 12 };
 
             //Act
             ConsequenceDistributionResults consequenceDistributionResults = ImpactAreaStageDamage.ComputeDamageOneCoordinate(medianRandomProvider, convergenceCriteria, inventory, impactAreaID, WSEs);

--- a/fda-model-test/unittests/UncertainPairedDataShould.cs
+++ b/fda-model-test/unittests/UncertainPairedDataShould.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Statistics.Histograms;
 using HEC.FDA.Model.paireddata;
 
-namespace fda_model_test.unittests
+namespace HEC.FDA.ModelTest.unittests
 {
     [Trait("Category", "Unit")]
     public class UncertainPairedDataShould
@@ -55,7 +55,7 @@ namespace fda_model_test.unittests
             double[] arrayOfProbabilities = new double[arraySize];
             for (int i = 0; i < arraySize; i++)
             {
-                arrayOfProbabilities[i] = (((double)i + 0.5)) / ((double)arraySize);
+                arrayOfProbabilities[i] = (i + 0.5) / arraySize;
             }
             double cumulativeArea = 0;
             for (int i = 0; i < arraySize; i++)
@@ -83,7 +83,7 @@ namespace fda_model_test.unittests
             double[] arrayOfProbabilities = new double[arraySize];
             for (int i = 0; i < arraySize; i++)
             {
-                arrayOfProbabilities[i] = (((double)i + 0.5)) / ((double)arraySize);
+                arrayOfProbabilities[i] = (i + 0.5) / arraySize;
             }
             object areaLock = new object();
             double cumulativeArea = 0;

--- a/fda-model-test/unittests/hydraulics/HydraulicDatasetShould.cs
+++ b/fda-model-test/unittests/hydraulics/HydraulicDatasetShould.cs
@@ -3,7 +3,7 @@ using Xunit;
 using HEC.FDA.Model.hydraulics;
 using HEC.FDA.Model.hydraulics.enums;
 
-namespace fda_model_test.unittests.hydraulics
+namespace HEC.FDA.ModelTest.unittests.hydraulics
 {
     [Trait("Category", "Unit")]
     public class HydraulicDatasetShould
@@ -13,16 +13,16 @@ namespace fda_model_test.unittests.hydraulics
         {
             List<HydraulicProfile> profiles = new List<HydraulicProfile>();
             double[] ExceedenceProbs = new double[] { 0.5, 0.99, 0.01 };
-            foreach(double prob in ExceedenceProbs)
+            foreach (double prob in ExceedenceProbs)
             {
-                profiles.Add(new HydraulicProfile(prob,"", HydraulicDataSource.UnsteadyHDF,""));
+                profiles.Add(new HydraulicProfile(prob, "", HydraulicDataSource.UnsteadyHDF, ""));
             }
             HydraulicDataset dataset = new HydraulicDataset(profiles);
 
             double[] expected = new double[] { 0.99, 0.5, 0.01 };
             double[] actual = new double[3];
             int count = 0;
-            foreach(HydraulicProfile profile in dataset.HydraulicProfiles)
+            foreach (HydraulicProfile profile in dataset.HydraulicProfiles)
             {
                 actual[count] = profile.Probability;
                 count++;

--- a/fda-model-test/unittests/hydraulics/HydraulicProfileShould.cs
+++ b/fda-model-test/unittests/hydraulics/HydraulicProfileShould.cs
@@ -4,7 +4,7 @@ using HEC.FDA.Model.hydraulics.enums;
 using HEC.FDA.Model.structures;
 using HEC.FDA.Model.hydraulics;
 
-namespace fda_model_test.unittests
+namespace HEC.FDA.ModelTest.unittests.hydraulics
 {
     [Trait("Category", "Unit")]
     public class HydraulicProfileShould
@@ -29,7 +29,7 @@ namespace fda_model_test.unittests
             Inventory inventory = new Inventory(pathToNSIShapefile, pathToIAShapefile, map, occupancyTypes);
             float[] wses = profile.GetWSE(inventory.GetPointMs());
             Assert.Equal(696, wses.Length); // All structures have a value
-            Assert.Equal(947.244446, wses[0],1); // first structure has correct WSE
+            Assert.Equal(947.244446, wses[0], 1); // first structure has correct WSE
         }
     }
 }

--- a/fda-model-test/unittests/hydraulics/HydraulicProfileShould.cs
+++ b/fda-model-test/unittests/hydraulics/HydraulicProfileShould.cs
@@ -17,7 +17,7 @@ namespace fda_model_test.unittests
         [Theory]
         [InlineData(pathToResult, HydraulicDataSource.UnsteadyHDF)]
         [InlineData(pathToResult, HydraulicDataSource.SteadyHDF)]
-        //[InlineData(pathToGrid, HydraulicDataSource.WSEGrid)]
+        [InlineData(pathToGrid, HydraulicDataSource.WSEGrid)]
 
         public void GetWSE(string path, HydraulicDataSource dataSource)
         {

--- a/fda-model-test/unittests/simulationShould.cs
+++ b/fda-model-test/unittests/simulationShould.cs
@@ -10,7 +10,7 @@ using HEC.FDA.Model.metrics;
 using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.compute;
 
-namespace fda_model_test.unittests
+namespace HEC.FDA.ModelTest.unittests
 {
     [Trait("Category", "Unit")]
     public class SimulationShould
@@ -24,7 +24,7 @@ namespace fda_model_test.unittests
         static string assetCat = "Structure";
         CurveMetaData metaData = new CurveMetaData(xLabel, yLabel, name, damCat, assetCat);
         static int id = 1;
-        private int seed =  3456;
+        private int seed = 3456;
 
         [Theory]
         [InlineData(150000)]
@@ -36,7 +36,7 @@ namespace fda_model_test.unittests
             IDistribution[] stages = new IDistribution[2];
             for (int i = 0; i < 2; i++)
             {
-                stages[i] = IDistributionFactory.FactoryUniform(0, 300000*i, 10);
+                stages[i] = IDistributionFactory.FactoryUniform(0, 300000 * i, 10);
             }
             UncertainPairedData flow_stage = new UncertainPairedData(Flows, stages, metaData);
             //create a damage distribution
@@ -49,7 +49,7 @@ namespace fda_model_test.unittests
             UncertainPairedData stage_damage = new UncertainPairedData(Stages, damages, metaData);
             List<UncertainPairedData> upd = new List<UncertainPairedData>();
             upd.Add(stage_damage);
-            
+
             Threshold threshold = new Threshold(1, convergenceCriteria, ThresholdEnum.ExteriorStage, 150000);//do we want to access this through _results?
             ImpactAreaScenarioSimulation simulation = ImpactAreaScenarioSimulation.builder(id)
                 .withFlowFrequency(flow_frequency)
@@ -58,7 +58,7 @@ namespace fda_model_test.unittests
                 .withAdditionalThreshold(threshold)
                 .build();
             MedianRandomProvider mrp = new MedianRandomProvider();
-            ImpactAreaScenarioResults impactAreaScenarioResult = simulation.Compute(mrp,convergenceCriteria); //here we test compute, below we test preview compute 
+            ImpactAreaScenarioResults impactAreaScenarioResult = simulation.Compute(mrp, convergenceCriteria); //here we test compute, below we test preview compute 
             double actual = impactAreaScenarioResult.MeanExpectedAnnualConsequences(id, damCat, assetCat);
             double difference = expected - actual;
             double relativeDifference = Math.Abs(difference / expected);
@@ -139,7 +139,7 @@ namespace fda_model_test.unittests
             RandomProvider randomProvider = new RandomProvider(seed);
             ConvergenceCriteria convergenceCriteria = new ConvergenceCriteria(minIterations: iterations, maxIterations: iterations);
             ImpactAreaScenarioResults results = simulation.Compute(randomProvider, convergenceCriteria);
-            double actual = results.MeanExpectedAnnualConsequences(id,damCat,assetCat);
+            double actual = results.MeanExpectedAnnualConsequences(id, damCat, assetCat);
             double difference = Math.Abs(actual - expected);
             double relativeDifference = difference / expected;
             double tolerance = 0.05;
@@ -159,7 +159,7 @@ namespace fda_model_test.unittests
             {
                 stages[i] = IDistributionFactory.FactoryUniform(0, 300000 * i, 10);
             }
-            UncertainPairedData flow_stage = new UncertainPairedData(Flows, stages,metaData);
+            UncertainPairedData flow_stage = new UncertainPairedData(Flows, stages, metaData);
             double epsilon = 0.0001;
             double[] leveestages = new double[] { 0.0d, topOfLeveeElevation - epsilon, topOfLeveeElevation };
             IDistribution[] leveefailprobs = new IDistribution[3];
@@ -192,7 +192,7 @@ namespace fda_model_test.unittests
             if (actual == 0) //handle assertion differently if EAD is zero
             {
                 Assert.Equal(expected, actual, 0);
-            } 
+            }
             else
             {
                 double difference = expected - actual;
@@ -200,14 +200,14 @@ namespace fda_model_test.unittests
                 double tolerance = 0.01;
                 Assert.True(relativeDifference < tolerance);
             }
-            
+
         }
 
         [Fact]
         public void SimulationReadsTheSameThingItWrites()
         {
             ConvergenceCriteria convergenceCriteria = new ConvergenceCriteria(minIterations: 1, maxIterations: 1);
-            ContinuousDistribution flow_frequency = new LogPearson3(1,1,1,200);
+            ContinuousDistribution flow_frequency = new LogPearson3(1, 1, 1, 200);
             //create a stage distribution
             IDistribution[] stages = new IDistribution[2];
             for (int i = 0; i < 2; i++)
@@ -242,7 +242,7 @@ namespace fda_model_test.unittests
         }
 
         [Theory]
-        [InlineData(0,true)]
+        [InlineData(0, true)]
         public void ComputeShouldReturnBlankResultsIfNoDamages(double expectedEAD, bool expectedZeroValued)
         {
             int impactAreaID = 1;
@@ -350,7 +350,7 @@ namespace fda_model_test.unittests
                 .build();
             ConvergenceCriteria convergenceCriteria = new ConvergenceCriteria(minIterations: 1, maxIterations: 1);
             MedianRandomProvider meanRandomProvider = new MedianRandomProvider();
-            ImpactAreaScenarioResults impactAreaScenarioResults = simulation.Compute(meanRandomProvider,convergenceCriteria);
+            ImpactAreaScenarioResults impactAreaScenarioResults = simulation.Compute(meanRandomProvider, convergenceCriteria);
             double actual = impactAreaScenarioResults.MeanExpectedAnnualConsequences();
             double difference = Math.Abs(actual - expected);
             double relativeDifference = difference / expected;
@@ -372,11 +372,11 @@ namespace fda_model_test.unittests
             IDistribution[] yStages = new IDistribution[] { new Uniform(5, 15), new Uniform(10, 30) };
             UncertainPairedData stageDischarge = new UncertainPairedData(xFlows, yStages, metaData);
             double[] xExteriorStages = new double[] { 10, 20, 30 };
-            IDistribution[] yInteriorStages = new IDistribution[] { new Uniform(0, 10), new Uniform(10, 20), new Uniform(30,30) };
+            IDistribution[] yInteriorStages = new IDistribution[] { new Uniform(0, 10), new Uniform(10, 20), new Uniform(30, 30) };
             UncertainPairedData interiorExterior = new UncertainPairedData(xExteriorStages, yInteriorStages, metaData);
             double[] xInteriorStages = new double[] { 5, 15, 30 };
             IDistribution[] yDamage = new IDistribution[] { new Uniform(0, 0), new Uniform(100, 300), new Uniform(100, 300) };
-            UncertainPairedData stageDamage = new UncertainPairedData(xInteriorStages,yDamage,metaData);
+            UncertainPairedData stageDamage = new UncertainPairedData(xInteriorStages, yDamage, metaData);
             List<UncertainPairedData> stageDamageList = new List<UncertainPairedData>() { stageDamage };
 
             int impactAreaID = 899;

--- a/fda-model-test/unittests/structures/DeterministicStructureShould.cs
+++ b/fda-model-test/unittests/structures/DeterministicStructureShould.cs
@@ -3,13 +3,13 @@ using HEC.FDA.Model.structures;
 using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.metrics;
 
-namespace fda_model_test.unittests.structures
+namespace HEC.FDA.ModelTest.unittests.structures
 {
     public class DeterministicStructureShould
     {
         private static string occupancyTypeName = "Res1-1NB";
         private static string occupancyTypeDamageCategory = "Residential";
-        private static double[] depths = new double[] {0,1,2,3,4,5,6,7,8};
+        private static double[] depths = new double[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 };
         private static double[] percentDamage = new double[] { 0, .10, .20, .30, .40, .50, .60, .70, .80 };
         private static PairedData structureDepthPercentDamage = new PairedData(depths, percentDamage);
         private static PairedData contentDepthPercentDamage = new PairedData(depths, percentDamage);
@@ -26,21 +26,21 @@ namespace fda_model_test.unittests.structures
 
 
         [Theory]
-        [InlineData(100,0,0)]
-        [InlineData(104,400,200)]
-        [InlineData(108,800,400)]
+        [InlineData(100, 0, 0)]
+        [InlineData(104, 400, 200)]
+        [InlineData(108, 800, 400)]
         public void DeterministicStructureShouldComputeDamageCorrectly(float waterSurfaceElevation, double expectedStructureDamage, double expectedContentDamage)
         {
             ConsequenceResult consequenceResult = deterministicStructure.ComputeDamage(waterSurfaceElevation);
-            Assert.Equal(expectedStructureDamage, consequenceResult.StructureDamage,0);
-            Assert.Equal(expectedContentDamage, consequenceResult.ContentDamage,0);
+            Assert.Equal(expectedStructureDamage, consequenceResult.StructureDamage, 0);
+            Assert.Equal(expectedContentDamage, consequenceResult.ContentDamage, 0);
         }
-    
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
+
     }
 }

--- a/fda-model-test/unittests/structures/FirstFloorElevationUncertaintyShould.cs
+++ b/fda-model-test/unittests/structures/FirstFloorElevationUncertaintyShould.cs
@@ -2,21 +2,21 @@
 using Statistics;
 using HEC.FDA.Model.structures;
 
-namespace fda_model_test.unittests.structures
+namespace HEC.FDA.ModelTest.unittests.structures
 {
     public class FirstFloorElevationUncertaintyShould
     {
         [Theory]
         [InlineData(IDistributionEnum.Normal, .5, 0, 5, .4, 4.873326)]
         [InlineData(IDistributionEnum.LogNormal, .2, 0, 2, .8, 8.74362)]
-        [InlineData(IDistributionEnum.Triangular, .5, 1, 5, .75,5.387628)]
-        [InlineData(IDistributionEnum.Uniform, .5, 1, 5, .45,5.175)]
-        [InlineData(IDistributionEnum.Deterministic, 203958, 20935, 10, .456,10)]
+        [InlineData(IDistributionEnum.Triangular, .5, 1, 5, .75, 5.387628)]
+        [InlineData(IDistributionEnum.Uniform, .5, 1, 5, .45, 5.175)]
+        [InlineData(IDistributionEnum.Deterministic, 203958, 20935, 10, .456, 10)]
         public void FirstFloorElevationShouldSampleCorrectly(IDistributionEnum distributionEnum, double standardDeviationOrMinimum, double maximum, double inventoriedFirstFloorElevation, double probability, double expected)
         {
             FirstFloorElevationUncertainty firstFloorElevationUncertainty = new FirstFloorElevationUncertainty(distributionEnum, standardDeviationOrMinimum, maximum);
             double actual = firstFloorElevationUncertainty.Sample(inventoriedFirstFloorElevation, probability);
-            Assert.Equal(expected, actual,1);
+            Assert.Equal(expected, actual, 1);
         }
     }
 }

--- a/fda-model-test/unittests/structures/InventoryShould.cs
+++ b/fda-model-test/unittests/structures/InventoryShould.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using HEC.FDA.Model.structures;
 
-namespace fda_model_test.unittests.structures
+namespace HEC.FDA.ModelTest.unittests.structures
 {
     [Trait("Category", "Unit")]
     public class InventoryShould

--- a/fda-model-test/unittests/structures/OccupancyTypeShould.cs
+++ b/fda-model-test/unittests/structures/OccupancyTypeShould.cs
@@ -5,7 +5,7 @@ using HEC.FDA.Model.structures;
 using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.compute;
 
-namespace fda_model_test.unittests.structures
+namespace HEC.FDA.ModelTest.unittests.structures
 {
     public class OccupancyTypeShould
     {
@@ -32,7 +32,7 @@ namespace fda_model_test.unittests.structures
         private static string damageCategory = "DamageCategory";
 
         [Theory]
-        [InlineData(100,10)]
+        [InlineData(100, 10)]
         public void OccupancyTypeShouldSampleCorrectly(double structureValue, double firstFloorElevation)
         {
             OccupancyType occupancyType = OccupancyType.builder()

--- a/fda-model-test/unittests/structures/StructureShould.cs
+++ b/fda-model-test/unittests/structures/StructureShould.cs
@@ -6,7 +6,7 @@ using HEC.FDA.Model.structures;
 using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.compute;
 
-namespace fda_model_test.unittests.structures
+namespace HEC.FDA.ModelTest.unittests.structures
 {
     public class StructureShould
     {
@@ -46,7 +46,7 @@ namespace fda_model_test.unittests.structures
         private static Structure structure = new Structure(structureID, pointM, firstFloorElevation, inventoriedStructureValue, damageCategory, occupancyTypeName, impactAreaID);
 
         [Theory]
-        [InlineData(1000, 100, 900, new double[] {0,10,20,30,40,50} )]
+        [InlineData(1000, 100, 900, new double[] { 0, 10, 20, 30, 40, 50 })]
         public void StructureShouldSampleCorrectly(double expectedStructureValue, double expectedFirstFloorElevation, double expectedContentValue, double[] expectedPercentDamage)
         {
             DeterministicStructure deterministicStructure = structure.Sample(medianRandomProvider, occupancyType);
@@ -54,6 +54,6 @@ namespace fda_model_test.unittests.structures
             Assert.Equal(expectedFirstFloorElevation, deterministicStructure.FirstFloorElevation);
             Assert.Equal(expectedContentValue, deterministicStructure.ContentValueSample);
             Assert.Equal(expectedPercentDamage, deterministicStructure.SampledStructureParameters.StructPercentDamagePairedData.Yvals);
-        } 
+        }
     }
 }

--- a/fda-model-test/unittests/structures/ValueRatioWithUncertaintyShould.cs
+++ b/fda-model-test/unittests/structures/ValueRatioWithUncertaintyShould.cs
@@ -2,12 +2,12 @@
 using Statistics;
 using HEC.FDA.Model.structures;
 
-namespace fda_model_test.unittests.structures
+namespace HEC.FDA.ModelTest.unittests.structures
 {
     public class ValueRatioWithUncertaintyShould
     {
         [Theory]
-        [InlineData(IDistributionEnum.Normal, .1, .6, 0, .95,.764485)]
+        [InlineData(IDistributionEnum.Normal, .1, .6, 0, .95, .764485)]
         [InlineData(IDistributionEnum.LogNormal, .57, -.85, 0, .05, .167367)]
         [InlineData(IDistributionEnum.Triangular, .7, .85, .9, .88, .865359)]
         [InlineData(IDistributionEnum.Uniform, .6, .8, .95, .40, .74)]

--- a/fda-model-test/unittests/structures/ValueUncertaintyShould.cs
+++ b/fda-model-test/unittests/structures/ValueUncertaintyShould.cs
@@ -2,7 +2,7 @@
 using Statistics;
 using HEC.FDA.Model.structures;
 
-namespace fda_model_test.unittests.structures
+namespace HEC.FDA.ModelTest.unittests.structures
 {
     public class ValueUncertaintyShould
     {
@@ -18,7 +18,7 @@ namespace fda_model_test.unittests.structures
         {
             ValueUncertainty valueUncertainty = new ValueUncertainty(distributionEnum, percentOfInventoryValueStandardDeviationOrMin, percentOfInventoryMax);
             double actual = valueUncertainty.Sample(inventoryValue, probability);
-            Assert.Equal(expected, actual,1);
+            Assert.Equal(expected, actual, 1);
         }
     }
 }

--- a/fda-model/HEC.FDA.Model.csproj
+++ b/fda-model/HEC.FDA.Model.csproj
@@ -21,8 +21,8 @@
 	<ItemGroup>
 		<!--Even though GDAL Assist is available as a transative dependency through Ras.Mapper, it needs
 		to be directly referenced as well to ensure GDAL is copied into the output directory.-->
-		<PackageReference Include="Geospatial.GDALAssist" Version="1.0.21-beta-g2e34768d8b" />
-		<PackageReference Include="Ras.Mapper" Version="1.0.21-beta-g2e34768d8b" />
+		<PackageReference Include="Geospatial.GDALAssist" Version="1.0.24-beta-gf5955b1108" />
+		<PackageReference Include="Ras.Mapper" Version="1.0.24-beta-gf5955b1108" />
 	</ItemGroup>
 
 

--- a/fda-model/hydraulics/HydraulicProfile.cs
+++ b/fda-model/hydraulics/HydraulicProfile.cs
@@ -37,7 +37,7 @@ namespace HEC.FDA.Model.hydraulics
 
         private float[] GetWSEFromGrids(PointMs pts)
         {
-            var baseDs = FloatTiffDataSource.TryLoad(FilePath);
+            var baseDs = TiffDataSource<float>.TryLoad(FilePath);
             if (baseDs == null)
             {
                 return new float[pts.Count];

--- a/fda-model/hydraulics/HydraulicProfile.cs
+++ b/fda-model/hydraulics/HydraulicProfile.cs
@@ -1,7 +1,10 @@
-﻿using HEC.FDA.Model.hydraulics.enums;
+﻿using Geospatial.IO;
+using Geospatial.Rasters;
+using HEC.FDA.Model.hydraulics.enums;
 using RasMapperLib;
 using RasMapperLib.Mapping;
 using System;
+using System.Collections.Generic;
 
 namespace HEC.FDA.Model.hydraulics
 {
@@ -34,8 +37,19 @@ namespace HEC.FDA.Model.hydraulics
 
         private float[] GetWSEFromGrids(PointMs pts)
         {
-            //TODO Sample off grids
-            return null;
+            var baseDs = FloatTiffDataSource.TryLoad(FilePath);
+            if (baseDs == null)
+            {
+                return new float[pts.Count];
+            }
+            RasterPyramid<float> baseRaster = baseDs.AsRasterizer();
+
+            List<Geospatial.Vectors.Point> geospatialpts = RasMapperLib.Utilities.Converter.Convert(pts);
+            Memory<Geospatial.Vectors.Point> points = new Memory<Geospatial.Vectors.Point>(geospatialpts.ToArray());
+            float[] elevationData = new float[points.Length];
+
+            baseRaster.SamplePoints(points, elevationData);
+            return elevationData;
         }
 
         private float[] GetWSEFromHDF(PointMs pts)


### PR DESCRIPTION
This pull request contains both the additional feature of sampling from grids and cleaning up the model test libraries namespaces.  Review should be focused only on the first two commits. Don't waste your time reviewing all the files related to the namespace change. 

Currently this will not pass tests as the Sample Points functionality for a raster is not yet available in the RASMapper libraries that are currently under development. I'll coordinate with our friends over there to get that accomplished. 