### PR TITLE
now catch all cases of dry structures, not just null data.

### DIFF
--- a/fda-model/hydraulics/HydraulicDataset.cs
+++ b/fda-model/hydraulics/HydraulicDataset.cs
@@ -59,13 +59,13 @@ namespace HEC.FDA.Model.hydraulics
         {
             float offsetForDryStructures = 9;
             float offsetForBarelyDryStructures = 2;
-            float dryCellValue = -9999;
             if (nextProfileWses == null)
             {
                 for (int i = 0; i < wsesToCorrect.Length; i++)
                 {
+                    bool dryInCurrentProfile = wsesToCorrect[i] < groundElevs[i];
                     //The case where the largest profile has dry structures
-                    if (wsesToCorrect[i] == dryCellValue)
+                    if (dryInCurrentProfile)
                     {
                         wsesToCorrect[i] = (groundElevs[i] - offsetForDryStructures);
                     }
@@ -73,10 +73,12 @@ namespace HEC.FDA.Model.hydraulics
             }
             for (int i = 0; i < wsesToCorrect.Length; i++)
             {
-                if (wsesToCorrect[i] == dryCellValue)
+                bool dryInNextProfile = nextProfileWses[i] < groundElevs[i];
+                bool dryInCurrentProfile = wsesToCorrect[i] < groundElevs[i];
+                if (dryInCurrentProfile)
                 {
                     //The case where the next largest profile is also dry
-                    if (nextProfileWses[i] == dryCellValue)
+                    if (dryInNextProfile)
                     {
                         wsesToCorrect[i] = (groundElevs[i] - offsetForDryStructures);
                     }


### PR DESCRIPTION
This fix captures this case. Where a structure exists in a cell with wildly varying terrain elevations. Sampling through an HDF file, we will get the WSE of that cell when we sample the structure at that point, even through the terrain is above the wse. This won't happen with grids. 

![image](https://user-images.githubusercontent.com/64556723/205172826-31b92444-71f0-4ec7-85d2-ef2d5e3c9332.png)

This is a simple solution. It will apply our default correction even if we have data for the "dry" event. If a structure is dry, it's damage will be calculated at Terrain - 2ft, or Terrain -9ft, even if it's only "dry" by 1ft. 

![image](https://user-images.githubusercontent.com/64556723/205173185-85a10057-1e6c-4e85-a686-cb4c3cb10842.png)

In the second drawing. even though we can see the WSE at the structures is calculated at 4ft. (1ft below the surface) for the 5YR event, we will end up using (5ft -2ft = 3ft) for the 5YR event damages, because we determined the structure dry, and applied our fix. 

We could potentially do this more accurately by using the 4ft value. We'll have to add some complexity in tracking when to do that though. 
