### PR TITLE
828 projection needs to be set at the study level

### DIFF
--- a/HEC.FDA.View/Study/Properties.xaml
+++ b/HEC.FDA.View/Study/Properties.xaml
@@ -7,7 +7,10 @@
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:UserControls="clr-namespace:UserControls.UserControls;assembly=HEC.FDA.UserControls"
              xmlns:ViewModel="clr-namespace:HEC.FDA.ViewModel.Study;assembly=HEC.FDA.ViewModel"
-             mc:Ignorable="d">
+             xmlns:local="clr-namespace:HEC.FDA.View.Study"
+             xmlns:framework="clr-namespace:HEC.MVVMFramework.View.UserControls;assembly=HEC.MVVMFramework.View"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance ViewModel:PropertiesVM}">
     <UserControl.Resources>
         <GridLength x:Key="FirstColumnWidth">130</GridLength>
         <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="MonetaryUnits">
@@ -24,6 +27,7 @@
     
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -149,7 +153,25 @@
             </Grid>
         </GroupBox>
 
-        <Utilities:SaveCloseControl Grid.Row="10" Grid.ColumnSpan="2" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="5"/>
+        <GroupBox Header="Study Projection" Grid.Row="10" Grid.ColumnSpan="2">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="{StaticResource FirstColumnWidth}" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <Label Content="Project Projection File" Grid.Column="0"/>
+                <framework:TextBoxFileBrowserControl FileDialogTitle="Select File" Filter="*.prj | *.prj"  Path="{Binding ProjectionPicker.ProjectProjectionPath}" Grid.Row="0" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="3,3,3,3" />
+                <TextBlock Text="{Binding ProjectionPicker.ASCIIProjection}" Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" TextWrapping="Wrap"/>
+
+            </Grid>
+        </GroupBox>
+
+        <Utilities:SaveCloseControl Grid.Row="11" Grid.ColumnSpan="2" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="5"/>
             
     </Grid>
 

--- a/HEC.FDA.ViewModel/HEC.FDA.ViewModel.csproj
+++ b/HEC.FDA.ViewModel/HEC.FDA.ViewModel.csproj
@@ -22,6 +22,7 @@
 		<ProjectReference Include="..\HEC.MVVMFramework.ViewModel\HEC.MVVMFramework.ViewModel.csproj" />
 	</ItemGroup>
 	<ItemGroup>
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0-preview2" />
 		<PackageReference Include="CsvHelper" Version="30.0.0" />
 		<PackageReference Include="PlottingLibrary2D" Version="1.0.0-beta-gdc08aa8621" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/HEC.FDA.ViewModel/Storage/Connection.cs
+++ b/HEC.FDA.ViewModel/Storage/Connection.cs
@@ -13,6 +13,7 @@ namespace HEC.FDA.ViewModel.Storage
         private static DatabaseManager.SQLiteManager _SqliteReader = null;
         private const string TERRAIN_DIRECTORY = "Terrains";
         private const string HYDRAULIC_DIRECTORY = "Hydraulic Data";
+        private const string PROJECTION_DIRECTORY = "Projection";
         private const string IMPACT_AREA_DIRECTORY = "Impact Areas";
         private const string INVENTORY_DIRECTORY = "Structure Inventories";
         private const string INDEX_POINTS_DIRECTORY = "Index Points";
@@ -65,18 +66,20 @@ namespace HEC.FDA.ViewModel.Storage
 
         private void SetUpForExistingStudy(string value)
         {
-            _ProjectDirectory = Path.GetDirectoryName(value);
-            if (!Directory.Exists(ProjectDirectory)) { Directory.CreateDirectory(ProjectDirectory); }
-            if (!Directory.Exists(TerrainDirectory)) { Directory.CreateDirectory(TerrainDirectory); }
-            if (!Directory.Exists(HydraulicsDirectory)) { Directory.CreateDirectory(HydraulicsDirectory); }
+            EnforceFolderStructure(value);
         }
         private void SetUpForNewStudy(string value)
+        {
+            EnforceFolderStructure(value);
+            DatabaseManager.SQLiteManager.CreateSqLiteFile(value);         
+        }
+        private void EnforceFolderStructure(string value)
         {
             _ProjectDirectory = Path.GetDirectoryName(value);
             if (!Directory.Exists(ProjectDirectory)) { Directory.CreateDirectory(ProjectDirectory); }
             if (!Directory.Exists(TerrainDirectory)) { Directory.CreateDirectory(TerrainDirectory); }
             if (!Directory.Exists(HydraulicsDirectory)) { Directory.CreateDirectory(HydraulicsDirectory); }
-            DatabaseManager.SQLiteManager.CreateSqLiteFile(value);         
+            if (!Directory.Exists(ProjectionDirectory)) { Directory.CreateDirectory(ProjectionDirectory); }
         }
 
         public DatabaseManager.SQLiteManager Reader
@@ -95,6 +98,10 @@ namespace HEC.FDA.ViewModel.Storage
         public string HydraulicsDirectory
         {
             get { return _ProjectDirectory + "\\" + HYDRAULIC_DIRECTORY; }
+        }
+        public string ProjectionDirectory
+        {
+            get { return _ProjectDirectory + "\\" + PROJECTION_DIRECTORY; }
         }
         public string ImpactAreaDirectory
         {

--- a/HEC.FDA.ViewModel/Study/ProjectionPickerVM.cs
+++ b/HEC.FDA.ViewModel/Study/ProjectionPickerVM.cs
@@ -1,0 +1,57 @@
+﻿using System.IO;
+using HEC.FDA.ViewModel.Editors;
+using HEC.FDA.ViewModel.Storage;
+using HEC.MVVMFramework.ViewModel.Implementations;
+
+namespace HEC.FDA.ViewModel.Study
+{
+	public class ProjectionPickerVM : ValidatingBaseViewModel
+    {
+        #region Backing Fields
+        private string _projectProjectionPath;
+        #endregion
+        #region Properties
+        public string ProjectProjectionPath
+		{
+			get { return _projectProjectionPath; }
+			set { _projectProjectionPath = value; NotifyPropertyChanged();NotifyPropertyChanged(nameof(ASCIIProjection)); }
+		}
+		public string ASCIIProjection
+		{
+			get
+			{
+				if (File.Exists(_projectProjectionPath))
+				{
+					return File.ReadAllText(_projectProjectionPath);
+				}
+				else
+				{
+					return "";
+				}
+			}
+		}
+        #endregion
+        #region Constructors
+        public ProjectionPickerVM()
+		{
+			GrabExistingProjection();
+        }
+        #endregion
+        #region Methods
+        private void GrabExistingProjection()
+		{
+			string[] filesInDirectory =  Directory.GetFiles(Connection.Instance.ProjectionDirectory);
+			if(filesInDirectory.Length > 0) { ProjectProjectionPath = filesInDirectory[0]; } 
+		}
+		public void Save()
+		{
+            string destination = Connection.Instance.ProjectionDirectory + Path.DirectorySeparatorChar + Path.GetFileName(ProjectProjectionPath);
+			if(File.Exists(_projectProjectionPath) && !_projectProjectionPath.Equals(destination) )
+			{
+                File.Copy(ProjectProjectionPath,destination);
+				ProjectProjectionPath = destination;
+            }
+		}
+        #endregion
+    }
+}

--- a/HEC.FDA.ViewModel/Study/PropertiesVM.cs
+++ b/HEC.FDA.ViewModel/Study/PropertiesVM.cs
@@ -34,6 +34,7 @@ namespace HEC.FDA.ViewModel.Study
         public double UpdatedPriceIndex { get; set; }
 
         public ConvergenceCriteriaVM ConvergenceCriteria { get; set; }
+        public ProjectionPickerVM ProjectionPicker { get; set; } = new ProjectionPickerVM();
 
         #endregion
         #region Constructors      
@@ -77,7 +78,7 @@ namespace HEC.FDA.ViewModel.Study
             int id = 1;
             StudyPropertiesElement elemToSave = new StudyPropertiesElement(StudyName, StudyPath, StudyDescription, CreatedBy,
                 CreatedDate, StudyNotes, MonetaryUnit, UnitSystem, SurveyedYear, UpdatedYear, UpdatedPriceIndex, DiscountRate, PeriodOfAnalysis, ConvergenceCriteria, id);
-
+            ProjectionPicker.Save(); 
             base.Save(elemToSave);
         }
         #endregion        


### PR DESCRIPTION
This sets up the MVP UI for projections. You are now able to specify a prj file to be the study projection. Upon saving the study properties, it will be copied into the study directory under the Projection folder. If a file already exists there, it will automattically populate as the project projection file. 

This has not been tied into the compute yet. That comes next, but I want to get this into main because it's a nice chunk of work and thought.