### PR TITLE
remove message hub from histograms.

### DIFF
--- a/HEC.FDA.Statistics/Histograms/Histogram.cs
+++ b/HEC.FDA.Statistics/Histograms/Histogram.cs
@@ -10,7 +10,7 @@ using Statistics.Distributions;
 
 namespace Statistics.Histograms
 {
-    public class Histogram: IHistogram, IReportMessage
+    public class Histogram: IHistogram
     {
         #region Fields
         private Int64[] _BinCounts = new Int64[] { };
@@ -179,7 +179,6 @@ namespace Statistics.Histograms
             {
                 AddObservationToHistogram(0);
             }
-            MessageHub.Register(this);
         }
         public Histogram(double min, double binWidth)
         {
@@ -189,14 +188,12 @@ namespace Statistics.Histograms
             int numberOfBins = 1;
             _BinCounts = new Int64[numberOfBins];
             _ConvergenceCriteria = new ConvergenceCriteria();
-            MessageHub.Register(this);
         }
         public Histogram(double binWidth)
         {
             _BinWidth = binWidth;
             _minHasNotBeenSet = true;
             _ConvergenceCriteria = new ConvergenceCriteria();
-            MessageHub.Register(this);
         }
         public Histogram(double min, double binWidth, ConvergenceCriteria convergenceCriteria)
         {
@@ -206,7 +203,6 @@ namespace Statistics.Histograms
             int numberOfBins = 1;
             _BinCounts = new Int64[numberOfBins];
             _ConvergenceCriteria = convergenceCriteria;
-            MessageHub.Register(this);
         }
         public Histogram(List<double> dataList, ConvergenceCriteria convergenceCriteria)
         {
@@ -227,7 +223,6 @@ namespace Statistics.Histograms
             }
             _BinCounts = new long[quantityOfBins];
             AddObservationsToHistogram(data);
-            MessageHub.Register(this);
         }
         private Histogram(double min, double max, double binWidth, Int64 sampleSize, Int64[] binCounts, ConvergenceCriteria convergenceCriteria)
         {
@@ -237,14 +232,9 @@ namespace Statistics.Histograms
             _BinCounts = binCounts;
             _ConvergenceCriteria = convergenceCriteria;
             _SampleSize = sampleSize;
-            MessageHub.Register(this);
         }
         #endregion
         #region Functions
-        public void ReportMessage(object sender, MessageEventArgs e)
-        {
-            MessageReport?.Invoke(sender, e);
-        }
         public double Skewness()
         {
             double deviation = 0, deviation2 = 0, deviation3 = 0;

--- a/HEC.FDA.Statistics/Histograms/IHistogram.cs
+++ b/HEC.FDA.Statistics/Histograms/IHistogram.cs
@@ -3,7 +3,7 @@ using System.Xml.Linq;
 using HEC.MVVMFramework.Base.Interfaces;
 namespace Statistics.Histograms
 {
-    public interface IHistogram: IReportMessage, IDistribution 
+    public interface IHistogram:  IDistribution 
     {
         #region Properties 
         bool IsConverged { get; }

--- a/HEC.FDA.Statistics/Histograms/ThreadsafeInlineHistogram.cs
+++ b/HEC.FDA.Statistics/Histograms/ThreadsafeInlineHistogram.cs
@@ -194,7 +194,6 @@ namespace Statistics.Histograms
             {
                 AddObservationToHistogram(0,i);
             }
-            MessageHub.Register(this);
         }
         public ThreadsafeInlineHistogram(ConvergenceCriteria c)
         {
@@ -203,7 +202,6 @@ namespace Statistics.Histograms
             _maxQueueCount = c.MinIterations;
             _backgroundWorker = new System.ComponentModel.BackgroundWorker();
             _backgroundWorker.DoWork += _bw_DoWork;
-            MessageHub.Register(this);
         }
         public ThreadsafeInlineHistogram(double binWidth, ConvergenceCriteria c, int startqueueSize = 10000, int postqueueSize = 100)
         {
@@ -214,7 +212,6 @@ namespace Statistics.Histograms
             _backgroundWorker.DoWork += _bw_DoWork;
             _maxQueueCount = startqueueSize;
             _postQueueCount = postqueueSize;
-            MessageHub.Register(this);
         }
         private ThreadsafeInlineHistogram(double min, double max, double binWidth, Int64[] binCounts, ConvergenceCriteria convergenceCriteria)
         {
@@ -232,7 +229,6 @@ namespace Statistics.Histograms
             _ConvergenceCriteria = convergenceCriteria;
             _backgroundWorker = new System.ComponentModel.BackgroundWorker();
             _backgroundWorker.DoWork += _bw_DoWork;
-            MessageHub.Register(this);
         }
         #endregion
 


### PR DESCRIPTION
des perez study now opens in ~3 minutes. Memory no longer the big issue. Further gains should come from parallelizing the bootstrap. which I'll work on next. 
