### PR TITLE
Dynamic Tab Unique Names

### DIFF
--- a/HEC.FDA.ViewModel/AggregatedStageDamage/AggregatedStageDamageOwnerElement.cs
+++ b/HEC.FDA.ViewModel/AggregatedStageDamage/AggregatedStageDamageOwnerElement.cs
@@ -18,17 +18,23 @@ namespace HEC.FDA.ViewModel.AggregatedStageDamage
             IsBold = false;
             CustomTreeViewHeader = new CustomHeaderVM(Name);
 
-            NamedAction addDamageCurve = new NamedAction();
-            addDamageCurve.Header = StringConstants.CREATE_NEW_STAGE_DAMAGE_MENU;
-            addDamageCurve.Action = AddNewStageDamageCurveSet;
+            NamedAction addDamageCurve = new()
+            {
+                Header = StringConstants.CREATE_NEW_STAGE_DAMAGE_MENU,
+                Action = AddNewStageDamageCurveSet
+            };
 
-            NamedAction importDamageCurve = new NamedAction();
-            importDamageCurve.Header = StringConstants.CreateImportFromFileMenuString(StringConstants.IMPORT_STAGE_DAMAGE_FROM_OLD_NAME);
-            importDamageCurve.Action = ImportNewStageDamageCurveSet;
+            NamedAction importDamageCurve = new()
+            {
+                Header = StringConstants.CreateImportFromFileMenuString(StringConstants.IMPORT_STAGE_DAMAGE_FROM_OLD_NAME),
+                Action = ImportNewStageDamageCurveSet
+            };
 
-            List<NamedAction> localActions = new List<NamedAction>();
-            localActions.Add(addDamageCurve);
-            localActions.Add(importDamageCurve);
+            List<NamedAction> localActions = new()
+            {
+                addDamageCurve,
+                importDamageCurve
+            };
 
             Actions = localActions;
 
@@ -59,7 +65,7 @@ namespace HEC.FDA.ViewModel.AggregatedStageDamage
             {
                 ImportFromFDA1VM vm = new ImportStageDamageFromFDA1VM();
                 string header = StringConstants.CreateImportHeader(StringConstants.IMPORT_STAGE_DAMAGE_FROM_OLD_NAME);
-                DynamicTabVM tab = new DynamicTabVM(header, vm, header);
+                DynamicTabVM tab = new(header, vm, header);
                 Navigate(tab, false, true);
             }
             else
@@ -87,9 +93,10 @@ namespace HEC.FDA.ViewModel.AggregatedStageDamage
                 EditorActionManager actionManager = new EditorActionManager()
                      .WithSiblingRules(this);
 
-                AggregatedStageDamageEditorVM vm = new AggregatedStageDamageEditorVM( actionManager);
+                AggregatedStageDamageEditorVM vm = new( actionManager);
                 string header = StringConstants.CREATE_NEW_STAGE_DAMAGE_HEADER;
-                DynamicTabVM tab = new DynamicTabVM(header, vm, header);
+                string uniqueSuffix = DateTime.Now.ToString();
+                DynamicTabVM tab = new(header, vm, header + uniqueSuffix);
                 Navigate(tab, false, true);
             }
         }

--- a/HEC.FDA.ViewModel/AlternativeComparisonReport/AlternativeComparisonReportOwnerElement.cs
+++ b/HEC.FDA.ViewModel/AlternativeComparisonReport/AlternativeComparisonReportOwnerElement.cs
@@ -12,12 +12,16 @@ namespace HEC.FDA.ViewModel.AlternativeComparisonReport
             Name = StringConstants.ALTERNATIVE_COMP_REPORTS;
             CustomTreeViewHeader = new CustomHeaderVM(Name);
 
-            NamedAction addAlternativeAction = new NamedAction();
-            addAlternativeAction.Header = StringConstants.CREATE_NEW_ALTERNATIVE_COMP_REPORTS_MENU;
-            addAlternativeAction.Action = AddNewAlternative;
+            NamedAction addAlternativeAction = new()
+            {
+                Header = StringConstants.CREATE_NEW_ALTERNATIVE_COMP_REPORTS_MENU,
+                Action = AddNewAlternative
+            };
 
-            List<NamedAction> localActions = new List<NamedAction>();
-            localActions.Add(addAlternativeAction);
+            List<NamedAction> localActions = new()
+            {
+                addAlternativeAction
+            };
 
             Actions = localActions;
 
@@ -44,9 +48,10 @@ namespace HEC.FDA.ViewModel.AlternativeComparisonReport
             Editors.EditorActionManager actionManager = new Editors.EditorActionManager()
                 .WithSiblingRules(this);
           
-            CreateNewAlternativeComparisonReportVM vm = new CreateNewAlternativeComparisonReportVM( actionManager);
+            CreateNewAlternativeComparisonReportVM vm = new( actionManager);
             string header = StringConstants.CREATE_NEW_ALTERNATIVE_COMP_REPORTS_HEADER;
-            DynamicTabVM tab = new DynamicTabVM(header, vm, header);
+            string uniqueSuffix = DateTime.Now.ToString();
+            DynamicTabVM tab = new(header, vm, header + uniqueSuffix);
             Navigate(tab, false, true);
         }
 

--- a/HEC.FDA.ViewModel/ImpactAreaScenario/IASOwnerElement.cs
+++ b/HEC.FDA.ViewModel/ImpactAreaScenario/IASOwnerElement.cs
@@ -5,6 +5,7 @@ using HEC.FDA.ViewModel.Editors;
 using HEC.FDA.ViewModel.ImpactArea;
 using HEC.FDA.ViewModel.Results;
 using HEC.FDA.ViewModel.Utilities;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 
 namespace HEC.FDA.ViewModel.ImpactAreaScenario
 {
@@ -19,22 +20,30 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario
             Name = StringConstants.SCENARIOS;
             CustomTreeViewHeader = new CustomHeaderVM(Name);
 
-            NamedAction addCondition = new NamedAction();
-            addCondition.Header = StringConstants.CREATE_NEW_SCENARIO_MENU;
-            addCondition.Action = AddNewIASSet;
+            NamedAction addCondition = new()
+            {
+                Header = StringConstants.CREATE_NEW_SCENARIO_MENU,
+                Action = AddNewIASSet
+            };
 
-            NamedAction computeAllMenu = new NamedAction();
-            computeAllMenu.Header = StringConstants.COMPUTE_SCENARIOS_MENU;
-            computeAllMenu.Action = ComputeScenarios;
+            NamedAction computeAllMenu = new()
+            {
+                Header = StringConstants.COMPUTE_SCENARIOS_MENU,
+                Action = ComputeScenarios
+            };
 
-            NamedAction viewSummaryResultsMenu = new NamedAction();
-            viewSummaryResultsMenu.Header = StringConstants.VIEW_SUMMARY_RESULTS_MENU;
-            viewSummaryResultsMenu.Action = ViewSummaryResults;
+            NamedAction viewSummaryResultsMenu = new()
+            {
+                Header = StringConstants.VIEW_SUMMARY_RESULTS_MENU,
+                Action = ViewSummaryResults
+            };
 
-            List<NamedAction> localActions = new List<NamedAction>();
-            localActions.Add(addCondition);
-            localActions.Add(computeAllMenu);
-            localActions.Add(viewSummaryResultsMenu);
+            List<NamedAction> localActions = new()
+            {
+                addCondition,
+                computeAllMenu,
+                viewSummaryResultsMenu
+            };
 
             Actions = localActions;
             StudyCache.IASElementAdded += AddIASElementSet;
@@ -70,9 +79,8 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario
         private void ChildElementUpdated(object sender, Saving.ElementUpdatedEventArgs args)
         {
             int removedElementID = args.NewElement.ID;
-            if (args.NewElement is ChildElement)
+            if (args.NewElement is ChildElement childElem)
             {
-                ChildElement childElem = (ChildElement)args.NewElement;
                 Saving.PersistenceFactory.GetIASManager().UpdateIASTooltipsChildElementModified(childElem, removedElementID);
             }
         }
@@ -88,9 +96,8 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario
         private void ChildElementRemoved(object sender, Saving.ElementAddedEventArgs args)
         {
             int removedElementID = args.Element.ID;
-            if (args.Element is ChildElement)
+            if (args.Element is ChildElement childElem)
             {
-                ChildElement childElem = (ChildElement)args.Element;
                 Saving.PersistenceFactory.GetIASManager().UpdateIASTooltipsChildElementModified(childElem, removedElementID);
             }
         }
@@ -113,17 +120,17 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario
 
         private void ComputeScenarios(object arg1, EventArgs arg2)
         {
-            ScenarioSelectorVM vm = new ScenarioSelectorVM();
+            ScenarioSelectorVM vm = new();
             vm.RequestNavigation += Navigate;
             //todo: add to string constants
-            DynamicTabVM tab = new DynamicTabVM(StringConstants.COMPUTE_SCENARIOS_HEADER, vm, StringConstants.COMPUTE_SCENARIOS_HEADER);
+            DynamicTabVM tab = new(StringConstants.COMPUTE_SCENARIOS_HEADER, vm, StringConstants.COMPUTE_SCENARIOS_HEADER);
             Navigate(tab, false, false);
         }
 
         private void ViewSummaryResults(object arg1, EventArgs arg2)
         {
             List<IASElement> elems = StudyCache.GetChildElementsOfType<IASElement>();
-            List<IASElement> elemsWithResults = new List<IASElement>();
+            List<IASElement> elemsWithResults = new();
             foreach(IASElement elem in elems)
             {
                 if(elem.Results != null)
@@ -132,8 +139,8 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario
                 }
             }
 
-            ScenarioDamageSummaryVM vm = new ScenarioDamageSummaryVM(elemsWithResults);
-            DynamicTabVM tab = new DynamicTabVM(StringConstants.VIEW_SUMMARY_RESULTS_HEADER, vm, StringConstants.VIEW_SUMMARY_RESULTS_HEADER);
+            ScenarioDamageSummaryVM vm = new(elemsWithResults);
+            DynamicTabVM tab = new(StringConstants.VIEW_SUMMARY_RESULTS_HEADER, vm, StringConstants.VIEW_SUMMARY_RESULTS_HEADER);
             Navigate(tab, false, false);
         }
 
@@ -148,9 +155,10 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario
             {
                 EditorActionManager actionManager = new EditorActionManager()
                      .WithSiblingRules(this);
-                Editor.IASEditorVM vm = new Editor.IASEditorVM(actionManager);
+                Editor.IASEditorVM vm = new(actionManager);
                 vm.RequestNavigation += Navigate;
-                DynamicTabVM tab = new DynamicTabVM(StringConstants.CREATE_NEW_SCENARIO_HEADER, vm, StringConstants.CREATE_NEW_SCENARIO_HEADER);
+                string uniqueSuffix = DateTime.Now.ToString();
+                DynamicTabVM tab = new(StringConstants.CREATE_NEW_SCENARIO_HEADER, vm, StringConstants.CREATE_NEW_SCENARIO_HEADER + uniqueSuffix);
                 Navigate(tab, false, false);
             }
 


### PR DESCRIPTION
we found we couldn't open a new tab for stage damage if there was already one open. I think the issue was lack of a unique name , which is the third argument in the dynamic tab constructor. 

I also just cleaned up some formatting. I really only want your confirmation that my fix makes sense to you with the dynamic tabs. IT seems to work in the UI. 