### PR TITLE
Address difficult to diagnose user errors when with importing SI 

### DIFF
--- a/HEC.FDA.Model/structures/RASHelper.cs
+++ b/HEC.FDA.Model/structures/RASHelper.cs
@@ -1,5 +1,8 @@
 ﻿using Geospatial.GDALAssist;
 using Geospatial.GDALAssist.Vectors;
+using Geospatial.IO;
+using Geospatial.Rasters;
+using Geospatial.Terrain;
 using RasMapperLib;
 using RasMapperLib.Utilities;
 using System;
@@ -11,18 +14,73 @@ namespace HEC.FDA.Model.structures;
 
 public static class RASHelper
 {
-    public static float[] GetGroundElevationFromRASTerrain(PointFeatureLayer pointLayer, TerrainLayer terrain, Projection studyProjection)
+    public static float[] SamplePointsFromRaster(string pointShapefilePath, string terrainLayerPath, Projection studyProjection)
     {
+        PointFeatureLayer pointLayer = new("thisNameIsntUsed", pointShapefilePath);
         Projection siProjection = GetVectorProjection(pointLayer);
         PointMs pointMs = new(pointLayer.Points().Select(p => p.PointM()));
-        if (!studyProjection.IsNull())
+        pointMs = ReprojectPoints(studyProjection, siProjection, pointMs);
+        string extension = System.IO.Path.GetExtension(terrainLayerPath);
+        float[] groundelevs;
+        switch (extension)
         {
-            if (!studyProjection.IsEqual(siProjection))
-            {
-                pointMs = ReprojectPoints(studyProjection, siProjection, pointMs);
-            }
+            case ".hdf":
+                TerrainLayer layer = new("thisNameIsNotUsed", terrainLayerPath);
+                groundelevs = layer.ComputePointElevations(pointMs);
+                break;
+            case ".tif":
+                groundelevs = SamplePointsOnTiff(pointMs, terrainLayerPath);
+                break;
+            default:
+                throw new Exception("The file type is invalid.");
         }
-        return terrain.ComputePointElevations(pointMs);
+        return groundelevs;
+
+        static PointMs ReprojectPoints(Projection targetProjection, Projection originalProjection, PointMs pointMs)
+        {
+
+            if (!targetProjection.IsNull())
+            {
+                if (!targetProjection.IsEqual(originalProjection))
+                {
+
+                }
+            }
+            return pointMs;
+        }
+    }
+    public static float[] SamplePointsOnTiff(PointMs pts, string filePath)
+    {
+        var baseDs = TiffDataSource<float>.TryLoad(filePath);
+        if (baseDs == null)
+        {
+            return new float[pts.Count];
+        }
+        RasterPyramid<float> baseRaster = baseDs.AsRasterizer();
+        List<Geospatial.Vectors.Point> geospatialpts = Converter.Convert(pts);
+        Memory<Geospatial.Vectors.Point> points = new(geospatialpts.ToArray());
+        float[] elevationData = new float[points.Length];
+        baseRaster.SamplePoints(points, elevationData);
+        return elevationData;
+    }
+    public static Projection GetProjectionFromTerrain(string TerrainPath)
+    {
+        string terrainExtension = System.IO.Path.GetExtension(TerrainPath);
+        string terrainTif;
+        switch (terrainExtension)
+        {
+            case ".hdf":
+                TerrainLayer terrain = new("ThisNameIsNotUSed", TerrainPath);
+                terrainTif = terrain.GetAllSourceFiles()[0];
+                break;
+            case ".tif":
+                terrainTif = TerrainPath;
+                break;
+            default:
+                throw new Exception("Unsupported File Type");
+        }
+        GDALRaster raster = new(terrainTif);
+        return raster.GetProjection();
     }
     public static int GetImpactAreaFID(PointM point, List<Polygon> ImpactAreas)
     {
@@ -51,12 +109,16 @@ public static class RASHelper
         return Converter.ConvertPtM(newp);
     }
 
-    public static PointMs ReprojectPoints(Projection studyProjection, Projection siProjection, PointMs pointMs)
+    public static PointMs ReprojectPoints(Projection targetProjection, Projection originalProjection, PointMs pointMs)
     {
+        if (targetProjection == null || targetProjection.IsEqual(originalProjection))
+        {
+            return pointMs;
+        }
         PointMs reprojPointMs = new();
         foreach (PointM pt in pointMs)
         {
-            reprojPointMs.Add(ReprojectPoint(pt, studyProjection, siProjection));
+            reprojPointMs.Add(ReprojectPoint(pt, targetProjection, originalProjection));
         }
         return reprojPointMs;
 

--- a/HEC.FDA.Model/structures/RASHelper.cs
+++ b/HEC.FDA.Model/structures/RASHelper.cs
@@ -108,7 +108,6 @@ public static class RASHelper
         Geospatial.Vectors.Point newp = VectorExtensions.Reproject(p, currentProjection, newProjection);
         return Converter.ConvertPtM(newp);
     }
-
     public static PointMs ReprojectPoints(Projection targetProjection, Projection originalProjection, PointMs pointMs)
     {
         if (targetProjection == null || targetProjection.IsEqual(originalProjection))
@@ -130,7 +129,6 @@ public static class RASHelper
         return Converter.Convert(reprojPoly);
 
     }
-
     public static T TryGet<T>(object value, T defaultValue = default)
 where T : struct
     {
@@ -182,7 +180,6 @@ where T : struct
         }
         return retval;
     }
-
     public static List<Polygon> LoadImpactAreasFromSourceFiles(PolygonFeatureLayer impactAreaSet, Projection studyProjection)
     {
         List<Polygon> polygons = impactAreaSet.Polygons().ToList();
@@ -200,7 +197,6 @@ where T : struct
             return ReprojectPolygons(studyProjection, polygons, impactAreaPrj);
         }
     }
-
     public static List<Polygon> ReprojectPolygons(Projection studyProjection, List<Polygon> polygons, Projection impactAreaPrj)
     {
         List<Polygon> ImpactAreas = new();
@@ -211,4 +207,28 @@ where T : struct
         }
         return ImpactAreas;
     }
+    public static List<string> GetTerrainComponentFiles(string terrainHDF, string extensionFilter)
+    {
+        TerrainLayer terrain = new("ThisNameIsNotUSed", terrainHDF);
+        List<string> allFiles = terrain.GetAllSourceFiles();
+        List<string> filteredFiles = new();
+        if (extensionFilter.IsNullOrEmpty())
+        {
+            filteredFiles = allFiles;
+        }
+        else
+        {
+            foreach (string file in allFiles)
+            {
+                if (System.IO.Path.GetExtension(file) == extensionFilter)
+                {
+                    filteredFiles.Add(file);
+                }
+            }
+        }
+        return filteredFiles;
+
+    }
+
+
 }

--- a/HEC.FDA.Model/structures/RASHelper.cs
+++ b/HEC.FDA.Model/structures/RASHelper.cs
@@ -71,7 +71,7 @@ public static class RASHelper
         {
             case ".hdf":
                 TerrainLayer terrain = new("ThisNameIsNotUSed", TerrainPath);
-                terrainTif = terrain.GetAllSourceFiles()[0];
+                terrainTif = terrain.GetAllSourceFiles()[1];
                 break;
             case ".tif":
                 terrainTif = TerrainPath;

--- a/HEC.FDA.Model/structures/Structure.cs
+++ b/HEC.FDA.Model/structures/Structure.cs
@@ -1,5 +1,4 @@
-﻿using HEC.FDA.Model.interfaces;
-using HEC.MVVMFramework.Base.Implementations;
+﻿using HEC.MVVMFramework.Base.Implementations;
 using HEC.MVVMFramework.Base.Enumerations;
 using RasMapperLib;
 using HEC.FDA.Model.metrics;

--- a/HEC.FDA.ModelTest/unittests/structures/InventoryShould.cs
+++ b/HEC.FDA.ModelTest/unittests/structures/InventoryShould.cs
@@ -75,7 +75,7 @@ namespace HEC.FDA.ModelTest.unittests.structures
         [Fact]
         public void GetGroundElevationFromTerrain()
         {
-            float[] groundelevs = Model.structures.RASHelper.GetGroundElevationFromRASTerrain(new PointFeatureLayer("ThisNameIsNotUsed",pathToNSIShapefile), new TerrainLayer("ThisNameIsNotUsed",pathToTerrainHDF),Projection.FromFile(pathToMuncieProjection));
+            float[] groundelevs = Model.structures.RASHelper.SamplePointsFromRaster(pathToNSIShapefile, pathToTerrainHDF,Projection.FromFile(pathToMuncieProjection));
             Assert.Equal(682, groundelevs.Length);
             Assert.Equal(946.5, groundelevs[0], 1);
         }

--- a/HEC.FDA.View/Watershed/TerrainBrowser.xaml
+++ b/HEC.FDA.View/Watershed/TerrainBrowser.xaml
@@ -7,23 +7,23 @@
         xmlns:local="clr-namespace:HEC.FDA.View.Watershed"
         xmlns:OkClose="clr-namespace:HEC.FDA.View.Utilities"
              >
-    <Grid>
-        <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="90"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-            <Label Content="Terrain Name" Grid.Row="0" Grid.Column="0" Margin="5" HorizontalAlignment="Right"/>
-        <TextBox Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="5" Text="{Binding Path=Name, Mode=TwoWay,ValidatesOnDataErrors=True}" />
+<Grid>
+  <Grid.RowDefinitions>
+    <RowDefinition Height="Auto"/>
+    <RowDefinition Height="Auto"/>
+    <RowDefinition Height="*"/>
+  </Grid.RowDefinitions>
+  <Grid.ColumnDefinitions>
+    <ColumnDefinition Width="90"/>
+    <ColumnDefinition Width="*"/>
+  </Grid.ColumnDefinitions>
+  <Label Content="Terrain Name" Grid.Row="0" Grid.Column="0" Margin="5" HorizontalAlignment="Right"/>
+  <TextBox Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="5" Text="{Binding Path=Name, Mode=TwoWay,ValidatesOnDataErrors=True}" />
 
-            <Label Content="Terrain Path" Grid.Row="1" Grid.Column="0" Margin="5" HorizontalAlignment="Right"/>
+  <Label Content="Terrain Path" Grid.Row="1" Grid.Column="0" Margin="5" HorizontalAlignment="Right"/>
 
-        <frameworkControls:TextBoxFileBrowserControl FileDialogTitle="Select File" Path="{Binding TerrainPath}" Grid.Row="1" Grid.Column="1"  Margin="5" Filter="Grid files (*.hdf;*.vrt;*.tif;*.flt)|*.hdf;*.vrt;*.tif;*.flt|All files (*.*) |*.*" />
+  <frameworkControls:TextBoxFileBrowserControl FileDialogTitle="Select File" Path="{Binding TerrainPath}" Grid.Row="1" Grid.Column="1"  Margin="5" Filter="Grid files (*.hdf;*.tif)|*.hdf;*.tif|All files (*.*) |*.*" />
 
-        <OkClose:OKCloseControl Grid.Row="2" Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Bottom" />
-    </Grid>
+  <OkClose:OKCloseControl Grid.Row="2" Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Bottom" />
+</Grid>
 </UserControl>

--- a/HEC.FDA.ViewModel/Inventory/ImportStructuresFromShapefileVM.cs
+++ b/HEC.FDA.ViewModel/Inventory/ImportStructuresFromShapefileVM.cs
@@ -161,7 +161,7 @@ namespace HEC.FDA.ViewModel.Inventory
 
         public bool NextButtonClicked()
         {
-            if(Storage.Connection.Instance.ProjectionFile == null)
+            if(Storage.Connection.Instance.ProjectionFile == null && ((TerrainElement)StudyCache.GetParentElementOfType<TerrainOwnerElement>().Elements[0] == null))
             {
                 MessageBox.Show("Please set your project projection in the study properties.", "Missing Projection", MessageBoxButton.OK, MessageBoxImage.Error);
                 return false;

--- a/HEC.FDA.ViewModel/Inventory/InventoryColumnSelectionsVM.cs
+++ b/HEC.FDA.ViewModel/Inventory/InventoryColumnSelectionsVM.cs
@@ -262,10 +262,10 @@ namespace HEC.FDA.ViewModel.Inventory
         /// <returns></returns>
         private List<StructureMissingDataRowItem> GetMissingTerrainElevations()
         {
-            List<StructureMissingDataRowItem> missingDataRows = new List<StructureMissingDataRowItem>();
+            List<StructureMissingDataRowItem> missingDataRows = new();
             int badElevationNumber = -9999;
             _StructureElevations.Clear();
-            _StructureElevations.AddRange(Model.structures.RASHelper.GetGroundElevationFromRASTerrain(new PointFeatureLayer("ThisNameIsNotUsed",Path), new TerrainLayer("ThisNameIsNotUsed",getTerrainFile()),Projection.FromFile(Storage.Connection.Instance.ProjectionFile)));
+            _StructureElevations.AddRange(RASHelper.SamplePointsFromRaster(Path,getTerrainFile(),RASHelper.GetProjectionFromTerrain(getTerrainFile())));
             List<int> idsWithNoElevation = new List<int>();
             for (int i = 0; i < _StructureElevations.Count(); i++)
             {

--- a/HEC.FDA.ViewModel/Watershed/TerrainBrowserVM.cs
+++ b/HEC.FDA.ViewModel/Watershed/TerrainBrowserVM.cs
@@ -1,4 +1,5 @@
-﻿using HEC.FDA.ViewModel.Editors;
+﻿using HEC.FDA.Model.structures;
+using HEC.FDA.ViewModel.Editors;
 using HEC.FDA.ViewModel.Saving;
 using HEC.FDA.ViewModel.Saving.PersistenceManagers;
 using HEC.FDA.ViewModel.Utilities;
@@ -6,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Windows;
+using Utilities;
 
 namespace HEC.FDA.ViewModel.Watershed
 {
@@ -17,7 +19,6 @@ namespace HEC.FDA.ViewModel.Watershed
         // Created Date: 10/11/2016 11:13:25 AM
         #endregion
         #region Fields
-        private const string VRT = ".vrt";
         private const string FLT = ".flt";
         private const string TIF = ".tif";
         private const string HDF = ".hdf";
@@ -42,91 +43,44 @@ namespace HEC.FDA.ViewModel.Watershed
 
         public override FdaValidationResult IsValid()
         {
-            FdaValidationResult vr = new FdaValidationResult();
-            if (TerrainPath != null && TerrainPath != "")
-            {
-                //check extension
-                string pathExtension = Path.GetExtension(TerrainPath);
-                if (VRT.Equals(pathExtension, StringComparison.OrdinalIgnoreCase))
-                {
-                    //if we have a vrt then we need to check that we only have one and that there are tifs next to it. 
-                    FdaValidationResult vrtResult = IsVRTPathValid();
-                    vr.AddErrorMessage(vrtResult.ErrorMessage);
-                }
-                else if (FLT.Equals(pathExtension, StringComparison.OrdinalIgnoreCase) || TIF.Equals(pathExtension, StringComparison.OrdinalIgnoreCase) || HDF.Equals(pathExtension, StringComparison.OrdinalIgnoreCase))
-                {
-                    //No special validation required.
-                }
-                else
-                {
-                    vr.AddErrorMessage("The file selected has an extension type of: '" + pathExtension + "'. Only .vrt, .tif, .hdf, and .flt are supported.");
-                }
-            }
-            else
+            FdaValidationResult vr = new();
+            if (TerrainPath.IsNullOrEmpty())
             {
                 vr.AddErrorMessage("A terrain file is required.");
             }
-            return vr;
-        }
-
-        private FdaValidationResult IsVRTPathValid()
-        {
-            FdaValidationResult vr = new FdaValidationResult();
-            string dirName = Path.GetDirectoryName(TerrainPath);
-            vr.AddErrorMessage(ContainsVRTAndTIF(dirName).ErrorMessage);
-            return vr;
-        }
-
-        private FdaValidationResult ContainsVRTAndTIF(string directoryPath)
-        {
-            FdaValidationResult vr = new FdaValidationResult();
-
-            List<string> tifFiles = new List<string>();
-            List<string> vrtFiles = new List<string>();
-
-            string[] fileList = Directory.GetFiles(directoryPath);
-            foreach (string file in fileList)
+            else
             {
-                if (Path.GetExtension(file) == TIF)
+                string pathExtension = Path.GetExtension(TerrainPath);
+                switch (pathExtension)
                 {
-                    tifFiles.Add(file);
-                }
-                if (Path.GetExtension(file) == VRT)
-                {
-                    vrtFiles.Add(file);
+                    case HDF:
+                        List<string> terrainCompFiles = RASHelper.GetTerrainComponentFiles(TerrainPath, null);
+                        if (!FilesExist(terrainCompFiles))
+                        {
+                            vr.AddErrorMessage("The file selected is missing it's component files.");
+                        }
+                        break;
+                    case TIF:
+                        // do nothing
+                        break;
+                    default:
+                        vr.AddErrorMessage("The file selected has an extension type of: '" + pathExtension + "'. Only .tif, and .hdf are supported.");
+                        break;
                 }
             }
-
-            string dirName = Path.GetFileNameWithoutExtension(directoryPath);
-
-            vr.AddErrorMessage(ValidateVRTFile(vrtFiles, dirName).ErrorMessage);
-            vr.AddErrorMessage(ValidateTIFFiles(tifFiles, dirName).ErrorMessage);
-
-            return vr;
-        }
-        private FdaValidationResult ValidateTIFFiles(List<string> tifFiles, string directoryName)
-        {
-            FdaValidationResult vr = new FdaValidationResult();
-            if (tifFiles.Count == 0)
-            {
-                vr.AddErrorMessage("Directory " + directoryName + ": No .tif files found.");
-            }
             return vr;
         }
 
-        private FdaValidationResult ValidateVRTFile(List<string> vrtFiles, string directoryName)
+        private static bool FilesExist(IEnumerable<string> files)
         {
-            FdaValidationResult vr = new FdaValidationResult();
-
-            if (vrtFiles.Count == 0)
+              foreach(string file in files)
             {
-                vr.AddErrorMessage("Directory " + directoryName + ": No .vrt file found.");
+                if (!File.Exists(file))
+                {
+                    return false;
+                }
             }
-            else if (vrtFiles.Count > 1)
-            {
-                vr.AddErrorMessage("Directory " + directoryName + ": More than one .vrt file found.");
-            }
-            return vr;
+            return true;
         }
 
         public override void Save()
@@ -139,10 +93,12 @@ namespace HEC.FDA.ViewModel.Watershed
                 int id = PersistenceFactory.GetTerrainManager().GetNextAvailableId();
                 //add a dummy element to the parent
                 string fileName = Path.GetFileName(TerrainPath);
-                TerrainElement t = new TerrainElement(Name, fileName, id, true);
+                TerrainElement t = new(Name, fileName, id, true);
                 StudyCache.GetParentElementOfType<TerrainOwnerElement>().AddElement(t);
-                TerrainElement newElement = new TerrainElement(Name, fileName, id);
-                newElement.LastEditDate = DateTime.Now.ToString("G");
+                TerrainElement newElement = new(Name, fileName, id)
+                {
+                    LastEditDate = DateTime.Now.ToString("G")
+                };
                 manager.SaveNew(TerrainPath, newElement);
                 IsCreatingNewElement = false;
                 HasChanges = false;


### PR DESCRIPTION
These updates address issues raised by @rtle76 when setting up a project.

These changes do 3 things
- We limit the file selector to HDF and TIF in the Terrain importer. 
- We now support Tif in the Terrain importer
- We now always reproject to the terrain projection automatically rather than relying on the user entered projection as long as there is a terrain available. 
