### PR TITLE
Bug/non fail preview compute

### DIFF
--- a/HEC.FDA.Model/paireddata/GraphicalUncertainPairedData.cs
+++ b/HEC.FDA.Model/paireddata/GraphicalUncertainPairedData.cs
@@ -93,7 +93,7 @@ namespace HEC.FDA.Model.paireddata
                 }
                 expandedStageOrLogFlowValues = tempArray;
             }
-            PairedData expandedPairedData = new PairedData(ExceedanceToNonExceedance(CombinedExceedanceProbabilities), expandedStageOrLogFlowValues);
+            PairedData expandedPairedData = new PairedData(ExceedanceToNonExceedance(CombinedExceedanceProbabilities), expandedStageOrLogFlowValues, CurveMetaData);
             return expandedPairedData;
         }
 

--- a/HEC.FDA.ViewModel/ImpactAreaScenario/Editor/SpecificIASEditorVM.cs
+++ b/HEC.FDA.ViewModel/ImpactAreaScenario/Editor/SpecificIASEditorVM.cs
@@ -533,8 +533,11 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario.Editor
             ExteriorInteriorElement extIntElem = SelectedExteriorInteriorElement.ChildElement as ExteriorInteriorElement;
             LateralStructureElement leveeElem = SelectedLeveeFeatureElement.ChildElement as LateralStructureElement;
             AggregatedStageDamageElement stageDamageElem = selectedStageDamage.ChildElement as AggregatedStageDamageElement;
-            AggregatedStageDamageElement nonFailureStageDamageElem = NonFailureSelectedStageDamage.ChildElement as AggregatedStageDamageElement;
-
+            AggregatedStageDamageElement nonFailureStageDamageElem = null;
+            if (_HasNonFailureStageDamage)
+            {
+                nonFailureStageDamageElem = NonFailureSelectedStageDamage.ChildElement as AggregatedStageDamageElement;
+            }
             SimulationCreator sc = new(freqElem, inOutElem, ratElem, extIntElem, leveeElem,
                 stageDamageElem, CurrentImpactArea.ID, _HasNonFailureStageDamage, nonFailureStageDamageElem);
 


### PR DESCRIPTION
It turns out that the non-fail stage damage functions are being handled completely different from the default stage damage functions. For example, they exist as different types.

I have added in validation to check whether there is a non fail, but we need to refactor these classes so that the two sets of stage damage functions are being handled similarly.