### PR TITLE
do not force max bin width of 100

### DIFF
--- a/HEC.FDA.Model/metrics/AggregatedConsequencesBinned.cs
+++ b/HEC.FDA.Model/metrics/AggregatedConsequencesBinned.cs
@@ -15,6 +15,7 @@ namespace HEC.FDA.Model.metrics
     public class AggregatedConsequencesBinned : IReportMessage, IProgressReport
     {
         #region Fields
+        private const int INITIAL_BIN_QUANTITY = 500;
         private readonly double[] _TempResults;
         private readonly double[] _TempCounts;
         private bool _HistogramNotConstructed = false;
@@ -91,23 +92,17 @@ namespace HEC.FDA.Model.metrics
         {
             if(_HistogramNotConstructed)
             {
-                int initialBinQuantity = 500;
                 double max = _TempResults.Max();
                 double min = _TempResults.Min();
                 double range = max - min;
                 double binWidth;
-                //following if else restricts bin width to be between 1 and 100.
-                if (range < initialBinQuantity)
+                if (range < INITIAL_BIN_QUANTITY)
                 {
                     binWidth = 1;
                 }
                 else
                 {
-                    binWidth = range / initialBinQuantity;
-                    if (binWidth > 100)
-                    {
-                        binWidth = 100;
-                    }
+                    binWidth = range / INITIAL_BIN_QUANTITY;
                 }
                 ConsequenceHistogram = new DynamicHistogram(binWidth, ConvergenceCriteria);
                 DamagedElementQuantityHistogram = new DynamicHistogram(binWidth:1, ConvergenceCriteria);


### PR DESCRIPTION
The initial fixed bin width of 100 was far too small Port Arthur PACR which has a wild range of content damage uncertainty. We'll start with a 500-bin histogram and let the initial bin width be 1/500th of the range of the initial sample. The histograms will then flex between about 500 bins and 2000 bins as the range grows further and resolution is iteratively reduced by a factor of 4. 

This fix exaggerates the problem documented in #1099 - I will create the fix on a separate branch. 