### PR TITLE
requirements for stage-damage removed

### DIFF
--- a/HEC.FDA.Model/metrics/ImpactAreaScenarioResults.cs
+++ b/HEC.FDA.Model/metrics/ImpactAreaScenarioResults.cs
@@ -246,13 +246,16 @@ namespace HEC.FDA.Model.metrics
         public PairedData GetDamageFrequency(string damageCategory, string assetCategory)
         {
             PairedData returnValue = new(new double[] {0, 1},new double[] {0, 1});
-            foreach ((CurveMetaData, PairedData) pairedData in DamageFrequencyFunctions)
+            if (DamageFrequencyFunctions != null)
             {
-                if (pairedData.Item1.DamageCategory ==  damageCategory)
+                foreach ((CurveMetaData, PairedData) pairedData in DamageFrequencyFunctions)
                 {
-                    if (pairedData.Item1.AssetCategory == assetCategory)
+                    if (pairedData.Item1.DamageCategory == damageCategory)
                     {
-                        returnValue = pairedData.Item2 as PairedData;
+                        if (pairedData.Item1.AssetCategory == assetCategory)
+                        {
+                            returnValue = pairedData.Item2 as PairedData;
+                        }
                     }
                 }
             }

--- a/HEC.FDA.View/ImpactAreaScenario/Editor/IASEditor.xaml
+++ b/HEC.FDA.View/ImpactAreaScenario/Editor/IASEditor.xaml
@@ -65,7 +65,7 @@
             <TextBlock  Grid.Column="1" Text="{Binding StageDamageText}" VerticalAlignment="Center" HorizontalAlignment="Right"  Margin="0,0,15,0"/>
             
 
-            <Label  Grid.Column="1" Content="*" Foreground="Red" HorizontalAlignment="Right" VerticalAlignment="Center" />
+            <Label  Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center" />
       <ComboBox  Grid.Column="2" Height="26" HorizontalAlignment="Stretch" ItemsSource="{Binding StageDamageElements}" DisplayMemberPath="Name" SelectedItem="{Binding SelectedStageDamageElement}" Margin="0,0,10,0" />
 
       <TextBlock  Grid.Column="3" Visibility="{Binding HasNonFailureStageDamage,Converter={StaticResource BoolToVisibilityConverter}}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,15,0">

--- a/HEC.FDA.ViewModel/ImpactAreaScenario/Editor/OverlappingRangeHelper.cs
+++ b/HEC.FDA.ViewModel/ImpactAreaScenario/Editor/OverlappingRangeHelper.cs
@@ -46,7 +46,10 @@ public static class OverlappingRangeHelper
                 //check outflows with rating flows
                 CheckRangeValues(SelectedRatingCurveElement, SelectedInflowOutflowElement, true, false, RATING, FLOW, messageRows);
                 //check rating stages with stage-damage stages
-                CheckRangeWithStageDamage(StageDamageElement, SelectedRatingCurveElement, SelectedDamageCurve, messageRows);
+                if (SelectedDamageCurve !=  null)
+                {
+                    CheckRangeWithStageDamage(StageDamageElement, SelectedRatingCurveElement, SelectedDamageCurve, messageRows);
+                }
             }
         }
         else if(ratingSelected)
@@ -55,7 +58,10 @@ public static class OverlappingRangeHelper
             CheckRangeValues(SelectedRatingCurveElement, SelectedFrequencyElement, true, false, RATING, FLOW, messageRows);
 
             //check rating stages with stage-damage stages
-            CheckRangeWithStageDamage(StageDamageElement, SelectedRatingCurveElement, SelectedDamageCurve, messageRows);
+            if (SelectedDamageCurve != null)
+            {
+                CheckRangeWithStageDamage(StageDamageElement, SelectedRatingCurveElement, SelectedDamageCurve, messageRows);
+            }
         }
     }
 

--- a/HEC.FDA.ViewModel/ImpactAreaScenario/Editor/SpecificIASEditorVM.cs
+++ b/HEC.FDA.ViewModel/ImpactAreaScenario/Editor/SpecificIASEditorVM.cs
@@ -492,27 +492,6 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario.Editor
             }
             return vr;
         }
-        private FdaValidationResult GetStageDamageValidationResult()
-        {
-            ChildElementComboItem selectedStageDamage = _SelectedStageDamage();
-            FdaValidationResult vr = new();
-            if (selectedStageDamage == null || selectedStageDamage.ChildElement == null)
-            {
-                vr.AddErrorMessage("A Stage Damage is required. ");
-            }
-            else
-            {
-                List<StageDamageCurve> stageDamageCurves = GetStageDamageCurves();
-                if (stageDamageCurves.Count == 0)
-                {
-                    //todo: maybe get the impact area name for this message?
-                    //todo: this name exists in multiple places. look into it. 
-                    vr.AddErrorMessage("The aggregated stage damage element '" + _SelectedStageDamage().ChildElement.Name + "' did not contain any curves that are associated " +
-                        "with the impact area.");
-                }
-            }
-            return vr;
-        }
 
         #endregion
 
@@ -530,25 +509,12 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario.Editor
             }
         }
 
-        private FdaValidationResult GetNonFailureValidationResult()
-        {
-            FdaValidationResult vr = new();
-            if (HasNonFailureStageDamage && (NonFailureSelectedStageDamage == null || NonFailureSelectedStageDamage.ChildElement == null))
-            {
-                //then a selection is required
-                vr.AddErrorMessage("A non failure stage-damage curve is required.");
-            }
-            return vr;
-        }
-
         public FdaValidationResult GetValidationResults()
         {
             FdaValidationResult vr = new();
 
             vr.AddErrorMessage(GetFrequencyRelationshipValidationResult().ErrorMessage);
             vr.AddErrorMessage(GetRatingCurveValidationResult().ErrorMessage);
-            vr.AddErrorMessage(GetStageDamageValidationResult().ErrorMessage);
-            vr.AddErrorMessage(GetNonFailureValidationResult().ErrorMessage);
 
             if (!vr.IsValid)
             {
@@ -580,9 +546,8 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario.Editor
                 sc.WithAdditionalThreshold(threshold);
             }
 
-            FdaValidationResult configurationValidationResult = sc.IsConfigurationValid();
-            if (configurationValidationResult.IsValid)
-            {
+            //might need to be able to handle no stage damage here elegantly 
+
                 ImpactAreaScenarioSimulation simulation = sc.BuildSimulation();
                 ImpactAreaScenarioResults result = simulation.PreviewCompute();
                 if (result == null)
@@ -594,7 +559,7 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario.Editor
                     EAD = result.ConsequenceResults.MeanDamage(_selectedDamageCategory, _selectedAssetCategory, CurrentImpactArea.ID);
                     _DamageFrequencyCurve = result.GetDamageFrequency(_selectedDamageCategory, _selectedAssetCategory);
                 }
-            }
+            
 
         }
 

--- a/HEC.FDA.ViewModel/ImpactAreaScenario/Results/PerformanceAEPVM.cs
+++ b/HEC.FDA.ViewModel/ImpactAreaScenario/Results/PerformanceAEPVM.cs
@@ -28,9 +28,9 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario.Results
                 Threshold threshold = thresholdComboItems[i].Metric;
                 ThresholdEnum thresholdType = threshold.ThresholdType;
                 int thresholdID = threshold.ThresholdID;
-                Mean = iasResult.MeanAEP(impactAreaID, thresholdID);
-                Median = iasResult.MedianAEP(impactAreaID, thresholdID);
-                NinetyPercentAssurance = iasResult.AEPWithGivenAssurance(impactAreaID, assurance:0.9, thresholdID);
+                double mean = iasResult.MeanAEP(impactAreaID, thresholdID);
+                double median = iasResult.MedianAEP(impactAreaID, thresholdID);
+                double ninetyPercentAssurance = iasResult.AEPWithGivenAssurance(impactAreaID, assurance:0.9, thresholdID);
                 List<IPerformanceRowItem> rows = new List<IPerformanceRowItem>();
                 //get the table values
                 List<double> xVals = new List<double>() { .1, .04, .02, .01, .004, .002 };
@@ -41,12 +41,16 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario.Results
                 }
 
                 MetricsToRows.Add(threshold, rows);
+                ThresholdToMetrics.Add(threshold, (mean, median, ninetyPercentAssurance));
                 LoadHistogramData(iasResult, impactAreaID, threshold);
             }
 
             if(MetricsToRows.Count>0)
             {
                 Rows = MetricsToRows.First().Value;
+                Mean = ThresholdToMetrics.First().Value.Item1;
+                Median = ThresholdToMetrics.First().Value.Item2;
+                NinetyPercentAssurance = ThresholdToMetrics.First().Value.Item3;
             }
         }
 

--- a/HEC.FDA.ViewModel/ImpactAreaScenario/Results/PerformanceVMBase.cs
+++ b/HEC.FDA.ViewModel/ImpactAreaScenario/Results/PerformanceVMBase.cs
@@ -4,6 +4,10 @@ using HEC.FDA.Model.metrics;
 
 namespace HEC.FDA.ViewModel.ImpactAreaScenario.Results
 {
+    /// <summary>
+    /// I very much dislike the design of this class. Some of the inhereting vms use the mean, median, ninety, and some don't. I'm not stoked about the threshhold dictionaries either. I'd like to take the time to rethink and refactor this someday if remain in this UI for
+    /// and extended period. TODO. 
+    /// </summary>
     public abstract class PerformanceVMBase : BaseViewModel
     {
         private List<IPerformanceRowItem> _rows;
@@ -28,6 +32,7 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario.Results
             set { _NinetyPctAssurance = value; NotifyPropertyChanged(); }
         }
         public Dictionary<Threshold, List<IPerformanceRowItem>> MetricsToRows { get;} = new Dictionary<Threshold, List<IPerformanceRowItem>>();
+        public Dictionary<Threshold, (double, double, double)> ThresholdToMetrics { get; } = [];
         public List<IPerformanceRowItem> Rows
         {
             get { return _rows; }
@@ -40,13 +45,19 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario.Results
             //Is there a reason that this is empty? 
         }
 
-        public void updateSelectedMetric(ThresholdComboItem metric)
+        public void UpdateSelectedMetric(ThresholdComboItem metric)
         {
             if (metric != null)
             {
                 if (MetricsToRows.ContainsKey(metric.Metric))
                 {
                     Rows = MetricsToRows[metric.Metric];
+                }
+                if(ThresholdToMetrics.ContainsKey(metric.Metric))
+                {
+                    Mean = ThresholdToMetrics[metric.Metric].Item1;
+                    Median = ThresholdToMetrics[metric.Metric].Item2;
+                    NinetyPercentAssurance = ThresholdToMetrics[metric.Metric].Item3;
                 }
                 UpdateHistogram(metric);
             }

--- a/HEC.FDA.ViewModel/ImpactAreaScenario/Results/SpecificIASResultVM.cs
+++ b/HEC.FDA.ViewModel/ImpactAreaScenario/Results/SpecificIASResultVM.cs
@@ -127,18 +127,18 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario.Results
       _damageWithUncertaintyVM = new DamageWithUncertaintyVM(scenarioResults,impactAreaID);
       _damageByDamageCategoryVM = new DamageByDamCatVM(_IASResult, damCats, discountRate, period);
       _performanceAEPVM = new PerformanceAEPVM(scenarioResults, impactAreaID, Thresholds);
-      _performanceAEPVM.updateSelectedMetric(SelectedThreshold);
+      _performanceAEPVM.UpdateSelectedMetric(SelectedThreshold);
       _performanceAssuranceOfThresholdVM = new PerformanceAssuranceOfThresholdVM(_IASResult, Thresholds);
-      _performanceAssuranceOfThresholdVM.updateSelectedMetric(SelectedThreshold);
+      _performanceAssuranceOfThresholdVM.UpdateSelectedMetric(SelectedThreshold);
       _performanceLongTermRiskVM = new PerformanceLongTermRiskVM(_IASResult, Thresholds);
-      _performanceLongTermRiskVM.updateSelectedMetric(SelectedThreshold);
+      _performanceLongTermRiskVM.UpdateSelectedMetric(SelectedThreshold);
     }
 
     private void ThresholdChanged()
     {
       if (_currentResultVM is PerformanceVMBase currentResult)
       {
-        currentResult.updateSelectedMetric(SelectedThreshold);
+        currentResult.UpdateSelectedMetric(SelectedThreshold);
       }
     }
 

--- a/HEC.FDA.ViewModel/ImpactAreaScenario/SpecificIAS.cs
+++ b/HEC.FDA.ViewModel/ImpactAreaScenario/SpecificIAS.cs
@@ -236,12 +236,7 @@ namespace HEC.FDA.ViewModel.ImpactAreaScenario
             {
                 vr.AddErrorMessage(CreateElementDoesntExistMessage("frequency element"));
             }
-            if (stageDamageElem == null)
-            {
-                vr.AddErrorMessage(CreateElementDoesntExistMessage("stage damage element"));
-            }
-
-        
+       
             return vr;
         }
 


### PR DESCRIPTION
I have removed requirements for a user to specify stage-damage functions.

## Editor
The editor no longer has asterisks on the stage-damage function combo box, and not selecting a set of stage-damage functions does not prevent a preview compute nor a full compute. 
![image](https://github.com/user-attachments/assets/b9b46fdb-687e-42d3-a2b7-9d90a18fe612)

## Results
Compute works as expected. No damage results but full performance results.
![image](https://github.com/user-attachments/assets/d314ac53-84e3-4ae5-9904-08914ea22cd3)
![image](https://github.com/user-attachments/assets/0ee04cac-2347-4dcf-b4fd-4ccc56337390)

## Consequences for user of not selecting stage-damage
Results will always be returned as 0, per design. If the user selects total risk and only provides nonfail because nonfail still has the requirement, we still return 0. 