### PR TITLE
Nuget config - t&c

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -28,12 +28,6 @@ jobs:
       with:
           dotnet-version: ${{ matrix.dotnet-version }} 
       
-    - name: Add Github and Nexus Source
-      run:  |
-        dotnet nuget add source --username HydrologicEngineeringCenter --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/HydrologicEngineeringCenter/index.json"
-        dotnet nuget add source --name fda-nuget "https://www.hec.usace.army.mil/nexus/repository/fda-nuget/"
-        dotnet nuget add source --name dss "https://www.hec.usace.army.mil/nexus/repository/dss/"
-      
     - name: Create version number
       shell: pwsh
       run: |

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -23,12 +23,6 @@ jobs:
       uses: actions/setup-dotnet@v3.2.0
       with:
           dotnet-version: '8.0.x'
-      
-    - name: Add Github and Nexus Source
-      run:  |
-        dotnet nuget add source --username HydrologicEngineeringCenter --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/HydrologicEngineeringCenter/index.json"
-        dotnet nuget add source --name fda-nuget "https://www.hec.usace.army.mil/nexus/repository/fda-nuget/"
-        dotnet nuget add source --name dss "https://www.hec.usace.army.mil/nexus/repository/dss/"
 
     - name: Create version number
       shell: pwsh

--- a/HEC.FDA.View/Utilities/SplashScreen.xaml
+++ b/HEC.FDA.View/Utilities/SplashScreen.xaml
@@ -116,7 +116,7 @@ and cease using the program).
     </RichTextBox>
     <Button
       Grid.Row="2"
-      Content="Close"
+      Content="Accept"
       Width="80"
       Height="22"
       HorizontalAlignment="Right"

--- a/HEC.FDA.View/Utilities/SplashScreen.xaml.cs
+++ b/HEC.FDA.View/Utilities/SplashScreen.xaml.cs
@@ -1,4 +1,8 @@
-﻿using System.Diagnostics;
+﻿using HEC.FDA.ViewModel.Utilities;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
@@ -54,6 +58,7 @@ namespace HEC.FDA.View.Utilities
         private void Button_Click(object sender, RoutedEventArgs e)
         {
             Window window = Window.GetWindow(this);
+            SplashScreenVM.TermsAndConditionsAccepted = true;
             window.Close();
         }
     }

--- a/HEC.FDA.ViewModel/Study/FdaStudyVM.cs
+++ b/HEC.FDA.ViewModel/Study/FdaStudyVM.cs
@@ -92,7 +92,12 @@ namespace HEC.FDA.ViewModel.Study
 
         public void LaunchSplashScreen()
         {
-            SplashScreenVM vm = new SplashScreenVM();
+            //don't throw up the splash screen if the t&c were already accepted
+            if (SplashScreenVM.TermsAndConditionsAccepted)
+            {
+                return;
+            }
+            SplashScreenVM vm = new();
             string header = "Terms and Conditions";
             DynamicTabVM tab = new DynamicTabVM(header, vm, "splashscreen", true, false);
             Navigate(tab, true, true);

--- a/HEC.FDA.ViewModel/Utilities/SplashScreenVM.cs
+++ b/HEC.FDA.ViewModel/Utilities/SplashScreenVM.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -8,7 +10,56 @@ namespace HEC.FDA.ViewModel.Utilities
 {
     public class SplashScreenVM : BaseViewModel
     {
+        public static bool TermsAndConditionsAccepted
+        {
+            get { return AreTermsAndConditionsAccepted(); }
+            set
+            {
+                if (value == true)
+                {
+                    RecordTermsAndConditionsAcceptance();
+                }
+            }
+        }
 
+        /// <summary>
+        /// Checks that terms and conditions have been accepted by this user profile, for this version of FDA. Returns true if the version is found in the text file 
+        /// </summary>
+        public static bool AreTermsAndConditionsAccepted()
+        {
+            string version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            string directoryPath = Path.Combine(appDataPath, "HEC", "HEC-FDA");
+            string filePath = Path.Combine(directoryPath, "terms_and_conditions_accepted.txt");
 
+            if (Path.Exists(filePath))
+            {
+                foreach (string line in File.ReadLines(filePath))
+                {
+                    if (line.Contains(version))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            return false;
+        }
+
+        public static void RecordTermsAndConditionsAcceptance()
+        {
+            string version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            string directoryPath = Path.Combine(appDataPath, "HEC", "HEC-FDA");
+            string filePath = Path.Combine(directoryPath, "terms_and_conditions_accepted.txt");
+
+            if (!Directory.Exists(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            using StreamWriter writer = new StreamWriter(filePath, true);
+            writer.WriteLine($"{version}");
+        }
     }
 }

--- a/nuget.config
+++ b/nuget.config
@@ -6,6 +6,5 @@
     <add key="dss-nuget" value="https://www.hec.usace.army.mil/nexus/repository/dss/" />
     <add key="ras-nuget-public" value="https://www.hec.usace.army.mil/nexus/repository/ras-nuget-public/" />
     <add key="Microsoft Visual Studio Offline Packages" value="C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\" />
-    <add key="HEC Github" value="https://nuget.pkg.github.com/HydrologicEngineeringCenter/index.json" />
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -4,7 +4,6 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="fda-nuget" value="https://www.hec.usace.army.mil/nexus/repository/fda-nuget/" />
     <add key="dss-nuget" value="https://www.hec.usace.army.mil/nexus/repository/dss/" />
-    <add key="ras-nuget-public" value="https://www.hec.usace.army.mil/nexus/repository/ras-nuget-public/" />
     <add key="Microsoft Visual Studio Offline Packages" value="C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\" />
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="fda-nuget" value="https://www.hec.usace.army.mil/nexus/repository/fda-nuget/" />
+    <add key="dss-nuget" value="https://www.hec.usace.army.mil/nexus/repository/dss/" />
+    <add key="ras-nuget-public" value="https://www.hec.usace.army.mil/nexus/repository/ras-nuget-public/" />
+    <add key="Microsoft Visual Studio Offline Packages" value="C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\" />
+    <add key="HEC Github" value="https://nuget.pkg.github.com/HydrologicEngineeringCenter/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
PR does two things
- Removes references to GitHub NuGet server which is no longer used for anything. Adds the necessary references to a repository level nuget.config, which should simplify new devs pulling the repo. 

- Adds a flag to %appdata% to check whether a user has already accepted the terms and conditions for this version before we throw up the splash screen. 