### PR TITLE
fixes issue with radio buttons not loading on initial open, as well a…

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -26,10 +26,6 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
           dotnet-version: ${{ env.dotnet-version }} 
-         
-    - name: Authenticate to ras-nuget-public
-      run: |
-        dotnet nuget update source ras-nuget-public --username ${{ secrets.HEC_NEXUS_READ_UID }} --password ${{ secrets.HEC_NEXUS_READ_PASSWORD }} --store-password-in-clear-text
 
     - name: Create version number
       shell: pwsh

--- a/HEC.FDA.View/FrequencyRelationships/FrequencyEditor/GraphicalControl.xaml
+++ b/HEC.FDA.View/FrequencyRelationships/FrequencyEditor/GraphicalControl.xaml
@@ -7,7 +7,12 @@
              mc:Ignorable="d" 
              xmlns:v="clr-namespace:HEC.MVVMFramework.View.NamedActionConverters;assembly=HEC.MVVMFramework.View"
              xmlns:vm ="clr-namespace:HEC.FDA.ViewModel.FrequencyRelationships.FrequencyEditor;assembly=HEC.FDA.ViewModel"
+             xmlns:conv ="clr-namespace:HEC.FDA.View.Utilities"
              d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{d:DesignInstance Type=vm:GraphicalVM }" d:Background="AliceBlue">
+  
+  <UserControl.Resources>
+    <conv:InverseBooleanConverter x:Key="InverseBooleanConverter" />
+  </UserControl.Resources>
   <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="35"/>
@@ -26,8 +31,16 @@
             <v:NamedActionButton NamedAction="{Binding ConfidenceLimits}" Margin="5" ToolTip="Not Needed For Compute" />
         </StackPanel>
         <StackPanel Orientation="Horizontal" Grid.Row="2">
-            <RadioButton Content="Flow" IsChecked="{Binding UseFlow}" Margin="5" GroupName="FlowStageRadio" x:Name="FlowRadioButton"/>
-            <RadioButton Content="Stage" Margin="5" GroupName="FlowStageRadio" x:Name="StageRadioButton"/>
+      <RadioButton Content="Flow"
+                   Margin="5"
+                   IsChecked="{Binding UseFlow, Mode=TwoWay}"
+                   GroupName="{Binding InstanceID, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                   x:Name="FlowRadioButton"/>
+      <RadioButton Content="Stage"
+                   Margin="5"
+                   IsChecked="{Binding UseFlow, Converter={StaticResource InverseBooleanConverter}, Mode=TwoWay}"
+                   GroupName="{Binding InstanceID, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                   x:Name="StageRadioButton"/>
         </StackPanel>
         <local:FdaDataGridControl DataContext="{Binding Path =SelectedItem }" Grid.Row="3"/>
     </Grid>

--- a/HEC.FDA.View/FrequencyRelationships/FrequencyEditor/GraphicalControl.xaml.cs
+++ b/HEC.FDA.View/FrequencyRelationships/FrequencyEditor/GraphicalControl.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows.Controls;
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
 
 namespace HEC.FDA.View.FrequencyRelationships.FrequencyEditor
 {
@@ -7,6 +9,16 @@ namespace HEC.FDA.View.FrequencyRelationships.FrequencyEditor
         public GraphicalControl()
         {
             InitializeComponent();
+            InstanceID = Guid.NewGuid().ToString();
         }
+
+        public string InstanceID
+        {
+            get { return (string)GetValue(InstanceIDProperty); }
+            set { SetValue(InstanceIDProperty, value); }
+        }
+
+        public static readonly DependencyProperty InstanceIDProperty =
+            DependencyProperty.Register("InstanceID", typeof(string), typeof(GraphicalControl), new PropertyMetadata(string.Empty));
     }
 }

--- a/HEC.FDA.ViewModel/HEC.FDA.ViewModel.csproj
+++ b/HEC.FDA.ViewModel/HEC.FDA.ViewModel.csproj
@@ -12,7 +12,7 @@
 		<ProjectReference Include="..\HEC.MVVMFramework.ViewModel\HEC.MVVMFramework.ViewModel.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0-preview2" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="PlottingLibrary2D" Version="1.0.0-beta-gdc08aa8621" />
 		<PackageReference Include="OxyPlot.Wpf" Version="2.1.2" />
 	</ItemGroup>


### PR DESCRIPTION
This PR does the following
- updates a view dependency to latest version
- changes the github workflow file to no longer authenticate for the RAS nuget dependency (it's now public read-only)
- fixes a bug where having multiple frequency curves open would sometimes show neither flow or stage selected for graphical 
- fixes a bug where graphical frequency curves (stage) would load with no radio button checked. 