### PR TITLE
Geospatial update

### DIFF
--- a/HEC.FDA.Model/HEC.FDA.Model.csproj
+++ b/HEC.FDA.Model/HEC.FDA.Model.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
-		<PackageReference Include="HEC.RAS.Ras.Mapper" Version="0.1.0.1421-dev" />
+		<PackageReference Include="HEC.RAS.Ras.Mapper" Version="0.1.0.1506-dev" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/HEC.FDA.Model/HEC.FDA.Model.csproj
+++ b/HEC.FDA.Model/HEC.FDA.Model.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
-		<PackageReference Include="HEC.RAS.Ras.Mapper" Version="0.1.0.1506-dev" />
+		<PackageReference Include="HEC.RAS.Ras.Mapper" Version="0.1.0.1554-dev" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/HEC.FDA.Model/Spatial/Extensions/Utility.cs
+++ b/HEC.FDA.Model/Spatial/Extensions/Utility.cs
@@ -9,7 +9,9 @@ public static class Utility
     public static T TryGetValueAs<T>(this TableRow row, string columnName, T fallbackValue = default) {
 		try
 		{
-			return row.ValueAs(columnName, fallbackValue);
+			if(string.IsNullOrWhiteSpace(columnName))
+                return fallbackValue;
+            return row.ValueAs(columnName, fallbackValue);
         }
 		catch (System.Exception)
 		{

--- a/HEC.FDA.Model/Spatial/Extensions/Utility.cs
+++ b/HEC.FDA.Model/Spatial/Extensions/Utility.cs
@@ -1,0 +1,19 @@
+﻿using Utility.Memory;
+
+namespace HEC.FDA.Model.Spatial.Extensions;
+public static class Utility
+{
+    /// <summary>
+    /// Tries to get the value of the specified column as the specified type. If the type is wrong, or column doesn't exist, returns fallback value
+    /// </summary>
+    public static T TryGetValueAs<T>(this TableRow row, string columnName, T fallbackValue = default) {
+		try
+		{
+			return row.ValueAs(columnName, fallbackValue);
+        }
+		catch (System.Exception)
+		{
+			return fallbackValue;
+		}
+    }
+}

--- a/HEC.FDA.Model/Spatial/PointShapefile.cs
+++ b/HEC.FDA.Model/Spatial/PointShapefile.cs
@@ -17,7 +17,7 @@ public class PointShapefile
 
     public PointShapefile(string pointShapefilePath)
     {
-        OperationResult res = ShapefileWriter.TryReadShapefile(pointShapefilePath, out _pointCollection);
+        OperationResult res = ShapefileIO.TryRead(pointShapefilePath, out _pointCollection);
         if (!res) 
         {
             throw new Exception(res.GetConcatenatedMessages(","));

--- a/HEC.FDA.Model/Spatial/RASHelper.cs
+++ b/HEC.FDA.Model/Spatial/RASHelper.cs
@@ -74,9 +74,23 @@ public static class RASHelper
         GdalBandedRaster<float> resultsGrid = new(filePath);
         Memory<Geospatial.Vectors.Point> points = new([.. geospatialpts]);
         float[] elevationData = new float[points.Length];
-        elevationData.Fill(Geospatial.Constants.NoDataF);
-        resultsGrid.SamplePoints(points, 0, elevationData);
+        resultsGrid.SamplePoints(points, 0, elevationData); //this writes float.MinValue for NoData.
+        OverwriteNoDataValues(ref elevationData);
         return elevationData;
+    }
+
+    /// <summary>
+    /// Checks for float.MinValue and replaces it with Geospatial.Constants.NoDataF
+    /// </summary>
+    private static void OverwriteNoDataValues(ref float[] elevations)
+    {
+        for(int i = 0; i<elevations.Length; i++)
+        {
+            if (elevations[i] == float.MinValue)
+            {
+                elevations[i] = Geospatial.Constants.NoDataF;
+            }
+        }
     }
 
     /// <summary>

--- a/HEC.FDA.Model/Spatial/RASHelper.cs
+++ b/HEC.FDA.Model/Spatial/RASHelper.cs
@@ -18,7 +18,6 @@ namespace HEC.FDA.Model.Spatial;
 
 public static class RASHelper
 {
-    private const string UNUSED_STRING = "";
 
     public static float[] SamplePointsFromRaster(PointMs pointMs, string rasterPath)
     {
@@ -131,17 +130,7 @@ public static class RASHelper
         GDALRaster raster = new(terrainTif);
         return raster.GetProjection();
     }
-    public static int GetImpactAreaFID(PointM point, List<Polygon> ImpactAreas)
-    {
-        for (int i = 0; i < ImpactAreas.Count; i++)
-        {
-            if (ImpactAreas[i].Contains(point))
-            {
-                return i;
-            }
-        }
-        return -9999;
-    }
+
     public static Projection GetVectorProjection(string fileName)
     {
         VectorDataset vector = new(fileName);
@@ -162,106 +151,7 @@ public static class RASHelper
         Geospatial.Vectors.Point newp = VectorExtensions.Reproject(p, currentProjection, newProjection);
         return Converter.ConvertPtM(newp);
     }
-    public static PointMs ReprojectPoints(Projection targetProjection, Projection originalProjection, PointMs pointMs)
-    {
-        if (targetProjection == null || targetProjection.IsEqual(originalProjection))
-        {
-            return pointMs;
-        }
-        PointMs reprojPointMs = new();
-        foreach (PointM pt in pointMs)
-        {
-            reprojPointMs.Add(ReprojectPoint(pt, targetProjection, originalProjection));
-        }
-        return reprojPointMs;
 
-    }
-    public static Polygon ReprojectPolygon(Polygon polygon, Projection newProjection, Projection currentProjection)
-    {
-        Geospatial.Vectors.Polygon poly = Converter.Convert(polygon);
-        Geospatial.Vectors.Polygon reprojPoly = VectorExtensions.Reproject(poly, currentProjection, newProjection);
-        return Converter.Convert(reprojPoly);
-
-    }
-    public static T TryGet<T>(object value, T defaultValue = default)
-where T : struct
-    {
-        if (value == null)
-            return defaultValue;
-        else if (value == DBNull.Value)
-            return defaultValue;
-        else
-        {
-            var retn = value as T?;
-            if (retn.HasValue)
-                return retn.Value;
-            else
-                return defaultValue;
-        }
-    }
-    public static string TryGetObj(object value, string defaultValue)
-    {
-        if (value == null)
-            return defaultValue;
-        else if (value == DBNull.Value)
-            return defaultValue;
-        else
-        {
-            string ret = value.ToString();
-            if (ret.IsNullOrEmpty())
-            {
-                ret = defaultValue;
-            }
-            return ret;
-        }
-    }
-    public static T GetRowValueForColumn<T>(System.Data.DataRow row, string mappingColumnName, T defaultValue) where T : struct
-    {
-        T retval = defaultValue;
-        if (mappingColumnName != null && row.Table.Columns.Contains(mappingColumnName))
-        {
-            //column could have wrong data type, or be null, or dbnull
-            retval = TryGet(row[mappingColumnName], defaultValue);
-        }
-        return retval;
-    }
-    public static string GetRowValueForColumn(System.Data.DataRow row, string mappingColumnName, string defaultValue)
-    {
-        string retval = defaultValue;
-        if (mappingColumnName != null && row.Table.Columns.Contains(mappingColumnName))
-        {
-            //column could have wrong data type, or be null, or dbnull
-            retval = TryGetObj(row[mappingColumnName], defaultValue);
-        }
-        return retval;
-    }
-    public static List<Polygon> LoadImpactAreasFromSourceFiles(PolygonFeatureLayer impactAreaSet, Projection studyProjection)
-    {
-        List<Polygon> polygons = impactAreaSet.Polygons().ToList();
-        Projection impactAreaPrj = GetVectorProjection(impactAreaSet);
-        if (studyProjection == null)
-        {
-            return polygons;
-        }
-        if (impactAreaPrj.IsEqual(studyProjection))
-        {
-            return polygons;
-        }
-        else
-        {
-            return ReprojectPolygons(studyProjection, polygons, impactAreaPrj);
-        }
-    }
-    public static List<Polygon> ReprojectPolygons(Projection studyProjection, List<Polygon> polygons, Projection impactAreaPrj)
-    {
-        List<Polygon> ImpactAreas = new();
-        foreach (Polygon poly in polygons)
-        {
-            Polygon newPoly = ReprojectPolygon(poly, impactAreaPrj, studyProjection);
-            ImpactAreas.Add(newPoly);
-        }
-        return ImpactAreas;
-    }
     /// <summary>
     /// returns all the component files of the terrain. Does not gaurantee they exist, just that they should for the terrain to be complete. 
     /// </summary>

--- a/HEC.FDA.Model/Spatial/RASHelper.cs
+++ b/HEC.FDA.Model/Spatial/RASHelper.cs
@@ -18,29 +18,9 @@ namespace HEC.FDA.Model.Spatial;
 
 public static class RASHelper
 {
-
-    public static float[] SamplePointsFromRaster(PointMs pointMs, string rasterPath)
-    {
-        string extension = System.IO.Path.GetExtension(rasterPath);
-        float[] groundelevs;
-        switch (extension)
-        {
-            case ".hdf":
-                TerrainLayer layer = new("thisNameIsNotUsed", rasterPath);
-                groundelevs = layer.ComputePointElevations(pointMs);
-                break;
-            case ".tif":
-                groundelevs = SamplePointsOnTiff(pointMs, rasterPath);
-                break;
-            default:
-                throw new Exception("The file type is invalid.");
-        }
-        return groundelevs;
-    }
-
     public static float[] SamplePointsFromRaster(string pointShapefilePath, string rasterPath, Projection rasterProjection)
     {
-        OperationResult or = ShapefileWriter.TryReadShapefile(pointShapefilePath, out PointFeatureCollection pointFeatures, rasterProjection);
+        OperationResult or = ShapefileIO.TryRead(pointShapefilePath, out PointFeatureCollection pointFeatures, rasterProjection);
         if (!or.Result)
         {
             throw new Exception("Failed to read shapefile: " + pointShapefilePath);
@@ -178,7 +158,7 @@ public static class RASHelper
     }
     public static bool IsPolygonShapefile(string path, ref string error)
     {
-        bool valid = ShapefileWriter.IsPolygonShapefile(path);
+        bool valid = ShapefileIO.IsPolygonShapefile(path);
         if (!valid)
         {
             error += " Not a polygon shapefile. ";
@@ -187,7 +167,7 @@ public static class RASHelper
     }
     public static bool IsPointShapefile(string path, ref string error)
     {
-        bool valid = ShapefileWriter.IsPointShapefile(path);
+        bool valid = ShapefileIO.IsPointShapefile(path);
         if (!valid)
         {
             error += " Not a point shapefile. ";

--- a/HEC.FDA.Model/Spatial/ShapefileLoader.cs
+++ b/HEC.FDA.Model/Spatial/ShapefileLoader.cs
@@ -11,6 +11,7 @@ using Geospatial.Vectors;
 using Utility.Logging;
 using Geospatial.GDALAssist.Vectors;
 using Utility.Memory;
+using HEC.FDA.Model.Spatial.Extensions;
 
 namespace HEC.FDA.Model.Spatial;
 public class ShapefileLoader
@@ -154,44 +155,44 @@ public class ShapefileLoader
             // Get the feature’s ID.
             string fid = GetFID(map, row);
 
-            double val_struct = row.ValueAs<double>(map.StructureValueCol, DEFAULT_MISSING_NUMBER_VALUE);
-            string occtype = row.ValueAs<string>(map.OccTypeCol, DEFAULT_MISSING_STRING_VALUE);
+            double val_struct = row.TryGetValueAs<double>(map.StructureValueCol, DEFAULT_MISSING_NUMBER_VALUE);
+            string occtype = row.TryGetValueAs<string>(map.OccTypeCol, DEFAULT_MISSING_STRING_VALUE);
             if (!occTypes.TryGetValue(occtype, out OccupancyType occ))
             {
                 return OperationResult.Fail($"Occupancy type {occtype} not found in the list of occupancy types.");
             }
             string st_damcat = occ.DamageCategory;
 
-            double found_ht = row.ValueAs<double>(map.FoundationHeightCol, DEFAULT_MISSING_NUMBER_VALUE);
-            double ground_elv = updateGroundElevFromTerrain ? groundelevs[i] : row.ValueAs<double>(map.GroundElevCol, DEFAULT_MISSING_NUMBER_VALUE);
-            double ff_elev = row.ValueAs<double>(map.FirstFloorElevCol, DEFAULT_MISSING_NUMBER_VALUE);
+            double found_ht = row.TryGetValueAs<double>(map.FoundationHeightCol, DEFAULT_MISSING_NUMBER_VALUE);
+            double ground_elv = updateGroundElevFromTerrain ? groundelevs[i] : row.TryGetValueAs<double>(map.GroundElevCol, DEFAULT_MISSING_NUMBER_VALUE);
+            double ff_elev = row.TryGetValueAs<double>(map.FirstFloorElevCol, DEFAULT_MISSING_NUMBER_VALUE);
             if (ff_elev == DEFAULT_MISSING_NUMBER_VALUE)
             {
                 ff_elev = ground_elv + found_ht;
             }
 
             // Optional parameters:
-            double val_cont = row.ValueAs<double>(map.ContentValueCol, 0);
-            double val_vehic = row.ValueAs<double>(map.VehicleValueCol, 0);
-            double val_other = row.ValueAs<double>(map.OtherValueCol, 0);
+            double val_cont = row.TryGetValueAs<double>(map.ContentValueCol, 0);
+            double val_vehic = row.TryGetValueAs<double>(map.VehicleValueCol, 0);
+            double val_other = row.TryGetValueAs<double>(map.OtherValueCol, 0);
             string cbfips = DEFAULT_MISSING_STRING_VALUE;
 
-            double beginningDamage = row.ValueAs<double>(map.BeginningDamageDepthCol, DEFAULT_MISSING_NUMBER_VALUE);
+            double beginningDamage = row.TryGetValueAs<double>(map.BeginningDamageDepthCol, DEFAULT_MISSING_NUMBER_VALUE);
             if (beginningDamage == DEFAULT_MISSING_NUMBER_VALUE)
             {
                 if (found_ht != DEFAULT_MISSING_NUMBER_VALUE)
                     beginningDamage = -found_ht;
             }
 
-            int numStructures = row.ValueAs<int>(map.NumberOfStructuresCol, 1);
-            int yearInService = row.ValueAs<int>(map.YearInConstructionCol, DEFAULT_MISSING_NUMBER_VALUE);
+            int numStructures = row.TryGetValueAs<int>(map.NumberOfStructuresCol, 1);
+            int yearInService = row.TryGetValueAs<int>(map.YearInConstructionCol, DEFAULT_MISSING_NUMBER_VALUE);
 
             // Get the point geometry from the feature.
             Geospatial.Vectors.Point point = structurePoints[i];
             int impactAreaID = GetImpactAreaFID(point, impactAreaCollection);
 
-            string notes = row.ValueAs<string>(map.NotesCol, DEFAULT_MISSING_STRING_VALUE);
-            string description = row.ValueAs<string>(map.DescriptionCol, DEFAULT_MISSING_STRING_VALUE);
+            string notes = row.TryGetValueAs<string>(map.NotesCol, DEFAULT_MISSING_STRING_VALUE);
+            string description = row.TryGetValueAs<string>(map.DescriptionCol, DEFAULT_MISSING_STRING_VALUE);
 
             // Create and add the new Structure.
             structures.Add(new Structure(
@@ -216,10 +217,10 @@ public class ShapefileLoader
     /// <returns></returns>
     private static string GetFID(StructureSelectionMapping map, TableRow row)
     {
-        string name = row.ValueAs(map.StructureIDCol, DEFAULT_MISSING_STRING_VALUE);
+        string name = row.TryGetValueAs(map.StructureIDCol, DEFAULT_MISSING_STRING_VALUE);
         if (name == DEFAULT_MISSING_STRING_VALUE){
             {
-                name = row.ValueAs(map.StructureIDCol, DEFAULT_MISSING_NUMBER_VALUE).ToString();
+                name = row.TryGetValueAs(map.StructureIDCol, DEFAULT_MISSING_NUMBER_VALUE).ToString();
             }
         }
         if (name == DEFAULT_MISSING_NUMBER_VALUE.ToString())

--- a/HEC.FDA.Model/Spatial/ShapefileLoader.cs
+++ b/HEC.FDA.Model/Spatial/ShapefileLoader.cs
@@ -10,6 +10,7 @@ using Geospatial.IO;
 using Geospatial.Vectors;
 using Utility.Logging;
 using Geospatial.GDALAssist.Vectors;
+using Utility.Memory;
 
 namespace HEC.FDA.Model.Spatial;
 public class ShapefileLoader
@@ -187,7 +188,7 @@ public class ShapefileLoader
 
             // Get the point geometry from the feature.
             Geospatial.Vectors.Point point = structurePoints[i];
-            int impactAreaID = GetImpactAreaFID(point, impactAreas);
+            int impactAreaID = GetImpactAreaFID(point, impactAreaCollection);
 
             string notes = row.ValueAs<string>(map.NotesCol, DEFAULT_MISSING_STRING_VALUE);
             string description = row.ValueAs<string>(map.DescriptionCol, DEFAULT_MISSING_STRING_VALUE);
@@ -213,12 +214,13 @@ public class ShapefileLoader
     /// <param name="map"></param>
     /// <param name="row"></param>
     /// <returns></returns>
-    private static string GetFID(StructureSelectionMapping map, System.Data.DataRow row)
+    private static string GetFID(StructureSelectionMapping map, TableRow row)
     {
-        string name = RASHelper.GetRowValueForColumn(row, map.StructureIDCol, DEFAULT_MISSING_STRING_VALUE);
-        if (name == DEFAULT_MISSING_STRING_VALUE)
-        {
-            name = RASHelper.GetRowValueForColumn(row, map.StructureIDCol, DEFAULT_MISSING_NUMBER_VALUE).ToString();
+        string name = row.ValueAs(map.StructureIDCol, DEFAULT_MISSING_STRING_VALUE);
+        if (name == DEFAULT_MISSING_STRING_VALUE){
+            {
+                name = row.ValueAs(map.StructureIDCol, DEFAULT_MISSING_NUMBER_VALUE).ToString();
+            }
         }
         if (name == DEFAULT_MISSING_NUMBER_VALUE.ToString())
         {
@@ -227,7 +229,7 @@ public class ShapefileLoader
         return name;
     }
 
-    public static int GetImpactAreaFID(PointM point, List<Polygon> ImpactAreas)
+    public static int GetImpactAreaFID(Geospatial.Vectors.Point point, PolygonFeatureCollection ImpactAreas)
     {
         for (int i = 0; i < ImpactAreas.Count; i++)
         {

--- a/HEC.FDA.Model/Spatial/ShapefileLoader.cs
+++ b/HEC.FDA.Model/Spatial/ShapefileLoader.cs
@@ -5,6 +5,11 @@ using System.Collections.Generic;
 using System.Linq;
 using HEC.FDA.Model.utilities;
 using HEC.FDA.Model.structures;
+using Geospatial.Features;
+using Geospatial.IO;
+using Geospatial.Vectors;
+using Utility.Logging;
+using Geospatial.GDALAssist.Vectors;
 
 namespace HEC.FDA.Model.Spatial;
 public class ShapefileLoader
@@ -35,79 +40,172 @@ public class ShapefileLoader
     {
         get { return _expectedTypes; }
     }
-    public static List<Structure> LoadStructuresFromSourceFiles(string pointShapefilePath, StructureSelectionMapping map, string terrrainFilePath, bool updateGroundElevFromTerrain,
-            string ImpactAreaShapefilePath, Projection studyProjection, Dictionary<string, OccupancyType> occTypes)
+
+    //[Obsolete("This method is deprecated. Use UpdatedLoadStructuresFromSourceFiles instead.")]
+    //public static List<Structure> LoadStructuresFromSourceFiles(string pointShapefilePath, StructureSelectionMapping map, string terrrainFilePath, bool updateGroundElevFromTerrain,
+    //        string impactAreaShapefilePath, Projection studyProjection, Dictionary<string, OccupancyType> occTypes)
+    //{
+    //    List<Structure> Structures = [];
+    //    PolygonFeatureLayer impactAreaFeatureLayer = new(UNUSED_STRING_VALUE, impactAreaShapefilePath);
+    //    List<Polygon> impactAreas = RASHelper.LoadImpactAreasFromSourceFiles(impactAreaFeatureLayer, studyProjection);
+    //    float[] groundelevs = Array.Empty<float>();
+    //    PointFeatureLayer structureFeatureLayer = new(UNUSED_STRING_VALUE, pointShapefilePath);
+    //    PointMs pointMs = new(structureFeatureLayer.Points().Select(p => p.PointM()));
+
+    //    //reproject right here. SI gets put into study projection immediately. 
+    //    Projection siProjection = RASHelper.GetVectorProjection(pointShapefilePath);
+    //    pointMs = RASHelper.ReprojectPoints(studyProjection, siProjection, pointMs);
+
+    //    if (updateGroundElevFromTerrain)
+    //    {
+    //        groundelevs = RASHelper.SamplePointsFromRaster(pointMs, terrrainFilePath);
+    //    }
+
+    //    for (int i = 0; i < structureFeatureLayer.FeatureCount(); i++)
+    //    {
+    //        //required parameters
+    //        PointM point = pointMs[i];
+    //        System.Data.DataRow row = structureFeatureLayer.FeatureRow(i);
+    //        string fid = GetFID(map, row);
+    //        double val_struct = RASHelper.GetRowValueForColumn<double>(row, map.StructureValueCol, DEFAULT_MISSING_NUMBER_VALUE);
+    //        string occtype = RASHelper.GetRowValueForColumn(row, map.OccTypeCol, DEFAULT_MISSING_STRING_VALUE);
+    //        string st_damcat = DEFAULT_MISSING_STRING_VALUE;
+    //        if (occTypes.ContainsKey(occtype))
+    //        {
+    //            st_damcat = occTypes[occtype].DamageCategory;
+    //            occtype = occTypes[occtype].Name;
+    //        }
+    //        //semi-required. We'll either have ff_elev given to us, or both ground elev and found_ht
+    //        double found_ht = RASHelper.GetRowValueForColumn<double>(row, map.FoundationHeightCol, DEFAULT_MISSING_NUMBER_VALUE); //not gauranteed
+    //        double ground_elv;
+    //        if (updateGroundElevFromTerrain)
+    //        {
+    //            ground_elv = groundelevs[i];
+    //        }
+    //        else
+    //        {
+    //            ground_elv = RASHelper.GetRowValueForColumn<double>(row, map.GroundElevCol, DEFAULT_MISSING_NUMBER_VALUE); //not gauranteed
+    //        }
+    //        double ff_elev = RASHelper.GetRowValueForColumn<double>(row, map.FirstFloorElevCol, DEFAULT_MISSING_NUMBER_VALUE); // not gauranteed  
+    //        if (ff_elev == DEFAULT_MISSING_NUMBER_VALUE)
+    //        {
+    //            ff_elev = ground_elv + found_ht;
+    //        }
+    //        //optional parameters
+    //        double val_cont = RASHelper.GetRowValueForColumn<double>(row, map.ContentValueCol, 0);
+    //        double val_vehic = RASHelper.GetRowValueForColumn<double>(row, map.VehicleValueCol, 0);
+    //        double val_other = RASHelper.GetRowValueForColumn<double>(row, map.OtherValueCol, 0);
+    //        string cbfips = DEFAULT_MISSING_STRING_VALUE;
+    //        double beginningDamage = RASHelper.GetRowValueForColumn<double>(row, map.BeginningDamageDepthCol, DEFAULT_MISSING_NUMBER_VALUE);
+    //        if (beginningDamage == DEFAULT_MISSING_NUMBER_VALUE)
+    //        {
+    //            if (found_ht != DEFAULT_MISSING_NUMBER_VALUE)
+    //            {
+    //                beginningDamage = -found_ht;
+    //            }
+    //        }
+    //        int numStructures = RASHelper.GetRowValueForColumn(row, map.NumberOfStructuresCol, 1);
+    //        int yearInService = RASHelper.GetRowValueForColumn(row, map.YearInConstructionCol, DEFAULT_MISSING_NUMBER_VALUE);
+    //        //TODO: handle number 
+    //        int impactAreaID = GetImpactAreaFID(point, impactAreas);
+    //        string notes = RASHelper.GetRowValueForColumn(row, map.NotesCol, DEFAULT_MISSING_STRING_VALUE);
+    //        string description = RASHelper.GetRowValueForColumn(row, map.DescriptionCol, DEFAULT_MISSING_STRING_VALUE);
+    //        Structures.Add(new Structure(fid, point, ff_elev, val_struct, st_damcat, occtype, impactAreaID, val_cont,
+    //            val_vehic, val_other, cbfips, beginningDamage, ground_elv, found_ht, yearInService, numStructures, notes, description));
+    //    }
+    //    return Structures;
+    //}
+
+
+
+    public static OperationResult LoadStructuresFromSourceFiles(string pointShapefilePath, StructureSelectionMapping map, string terrrainFilePath, bool updateGroundElevFromTerrain,
+            string impactAreaShapefilePath, Projection studyProjection, Dictionary<string, OccupancyType> occTypes, out List<Structure> structures)
     {
-        List<Structure> Structures = [];
-        PolygonFeatureLayer impactAreaFeatureLayer = new(UNUSED_STRING_VALUE, ImpactAreaShapefilePath);
-        List<Polygon> impactAreas = RASHelper.LoadImpactAreasFromSourceFiles(impactAreaFeatureLayer, studyProjection);
-        float[] groundelevs = Array.Empty<float>();
-        PointFeatureLayer structureFeatureLayer = new(UNUSED_STRING_VALUE, pointShapefilePath);
-        PointMs pointMs = new(structureFeatureLayer.Points().Select(p => p.PointM()));
+        structures = [];
 
-        //reproject right here. SI gets put into study projection immediately. 
-        Projection siProjection = RASHelper.GetVectorProjection(pointShapefilePath);
-        pointMs = RASHelper.ReprojectPoints(studyProjection, siProjection, pointMs);
-
-        if (updateGroundElevFromTerrain)
+        // 1. Read the Impact Area shapefile (polygons) 
+        OperationResult impactResult = ShapefileWriter.TryReadShapefile(impactAreaShapefilePath, out PolygonFeatureCollection impactAreaCollection, studyProjection);
+        if (!impactResult.Result)
         {
-            groundelevs = RASHelper.SamplePointsFromRaster(pointMs, terrrainFilePath);
+            return impactResult;
         }
 
-        for (int i = 0; i < structureFeatureLayer.FeatureCount(); i++)
+        // 2. Read the structure shapefile (points)
+        OperationResult pointResult = ShapefileWriter.TryReadShapefile(pointShapefilePath, out PointFeatureCollection structurePoints, studyProjection);
+        if (!pointResult.Result)
         {
-            //required parameters
-            PointM point = pointMs[i];
-            System.Data.DataRow row = structureFeatureLayer.FeatureRow(i);
+            return impactResult;
+        }
+
+        // 3. If we have to update the ground elevations from the terrain, then do so now.
+        float[] groundelevs = []; //initialized so we can ref it later even if we don't update it.
+        if (updateGroundElevFromTerrain)
+        {
+            groundelevs = RASHelper.SamplePointsFromRaster(structurePoints.Features, terrrainFilePath);
+        }
+
+        // 4. Now loop through each feature in the point collection.
+        for (int i = 0; i < structurePoints.Count; i++)
+        {
+            // Obtain the attribute row for this feature.
+            var row = structurePoints.AttributeTable.Rows[i];
+
+            // Get the feature’s ID.
             string fid = GetFID(map, row);
-            double val_struct = RASHelper.GetRowValueForColumn<double>(row, map.StructureValueCol, DEFAULT_MISSING_NUMBER_VALUE);
-            string occtype = RASHelper.GetRowValueForColumn(row, map.OccTypeCol, DEFAULT_MISSING_STRING_VALUE);
-            string st_damcat = DEFAULT_MISSING_STRING_VALUE;
-            if (occTypes.ContainsKey(occtype))
+
+            double val_struct = row.ValueAs<double>(map.StructureValueCol, DEFAULT_MISSING_NUMBER_VALUE);
+            string occtype = row.ValueAs<string>(map.OccTypeCol, DEFAULT_MISSING_STRING_VALUE);
+            if (!occTypes.TryGetValue(occtype, out OccupancyType occ))
             {
-                st_damcat = occTypes[occtype].DamageCategory;
-                occtype = occTypes[occtype].Name;
+                return OperationResult.Fail($"Occupancy type {occtype} not found in the list of occupancy types.");
             }
-            //semi-required. We'll either have ff_elev given to us, or both ground elev and found_ht
-            double found_ht = RASHelper.GetRowValueForColumn<double>(row, map.FoundationHeightCol, DEFAULT_MISSING_NUMBER_VALUE); //not gauranteed
-            double ground_elv;
-            if (updateGroundElevFromTerrain)
-            {
-                ground_elv = groundelevs[i];
-            }
-            else
-            {
-                ground_elv = RASHelper.GetRowValueForColumn<double>(row, map.GroundElevCol, DEFAULT_MISSING_NUMBER_VALUE); //not gauranteed
-            }
-            double ff_elev = RASHelper.GetRowValueForColumn<double>(row, map.FirstFloorElevCol, DEFAULT_MISSING_NUMBER_VALUE); // not gauranteed  
+            string st_damcat = occ.DamageCategory;
+
+            double found_ht = row.ValueAs<double>(map.FoundationHeightCol, DEFAULT_MISSING_NUMBER_VALUE);
+            double ground_elv = updateGroundElevFromTerrain ? groundelevs[i] : row.ValueAs<double>(map.GroundElevCol, DEFAULT_MISSING_NUMBER_VALUE);
+            double ff_elev = row.ValueAs<double>(map.FirstFloorElevCol, DEFAULT_MISSING_NUMBER_VALUE);
             if (ff_elev == DEFAULT_MISSING_NUMBER_VALUE)
             {
                 ff_elev = ground_elv + found_ht;
             }
-            //optional parameters
-            double val_cont = RASHelper.GetRowValueForColumn<double>(row, map.ContentValueCol, 0);
-            double val_vehic = RASHelper.GetRowValueForColumn<double>(row, map.VehicleValueCol, 0);
-            double val_other = RASHelper.GetRowValueForColumn<double>(row, map.OtherValueCol, 0);
+
+            // Optional parameters:
+            double val_cont = row.ValueAs<double>(map.ContentValueCol, 0);
+            double val_vehic = row.ValueAs<double>(map.VehicleValueCol, 0);
+            double val_other = row.ValueAs<double>(map.OtherValueCol, 0);
             string cbfips = DEFAULT_MISSING_STRING_VALUE;
-            double beginningDamage = RASHelper.GetRowValueForColumn<double>(row, map.BeginningDamageDepthCol, DEFAULT_MISSING_NUMBER_VALUE);
+
+            double beginningDamage = row.ValueAs<double>(map.BeginningDamageDepthCol, DEFAULT_MISSING_NUMBER_VALUE);
             if (beginningDamage == DEFAULT_MISSING_NUMBER_VALUE)
             {
                 if (found_ht != DEFAULT_MISSING_NUMBER_VALUE)
-                {
                     beginningDamage = -found_ht;
-                }
             }
-            int numStructures = RASHelper.GetRowValueForColumn(row, map.NumberOfStructuresCol, 1);
-            int yearInService = RASHelper.GetRowValueForColumn(row, map.YearInConstructionCol, DEFAULT_MISSING_NUMBER_VALUE);
-            //TODO: handle number 
+
+            int numStructures = row.ValueAs<int>(map.NumberOfStructuresCol, 1);
+            int yearInService = row.ValueAs<int>(map.YearInConstructionCol, DEFAULT_MISSING_NUMBER_VALUE);
+
+            // Get the point geometry from the feature.
+            Geospatial.Vectors.Point point = structurePoints[i];
             int impactAreaID = GetImpactAreaFID(point, impactAreas);
-            string notes = RASHelper.GetRowValueForColumn(row, map.NotesCol, DEFAULT_MISSING_STRING_VALUE);
-            string description = RASHelper.GetRowValueForColumn(row, map.DescriptionCol, DEFAULT_MISSING_STRING_VALUE);
-            Structures.Add(new Structure(fid, point, ff_elev, val_struct, st_damcat, occtype, impactAreaID, val_cont,
-                val_vehic, val_other, cbfips, beginningDamage, ground_elv, found_ht, yearInService, numStructures, notes, description));
+
+            string notes = row.ValueAs<string>(map.NotesCol, DEFAULT_MISSING_STRING_VALUE);
+            string description = row.ValueAs<string>(map.DescriptionCol, DEFAULT_MISSING_STRING_VALUE);
+
+            // Create and add the new Structure.
+            structures.Add(new Structure(
+                fid, point, ff_elev, val_struct, st_damcat, occtype,
+                impactAreaID, val_cont, val_vehic, val_other,
+                cbfips, beginningDamage, ground_elv, found_ht,
+                yearInService, numStructures, notes, description));
         }
-        return Structures;
+
+        return OperationResult.Success();
     }
+
+
+
+
 
     /// <summary>
     /// FID is commonly either string or int. This method will allow us to accept both. Tries to get string, if it fails, tries to get int. If it fails again, returns a default missing string value. 

--- a/HEC.FDA.Model/Spatial/ShapefileLoader.cs
+++ b/HEC.FDA.Model/Spatial/ShapefileLoader.cs
@@ -18,8 +18,6 @@ public class ShapefileLoader
 {
     private const string DEFAULT_MISSING_STRING_VALUE = "EMPTY";
     private const int DEFAULT_MISSING_NUMBER_VALUE = IntegerGlobalConstants.DEFAULT_MISSING_VALUE;
-    private const string UNUSED_STRING_VALUE = "";
-
     public static readonly Dictionary<string, Type> _expectedTypes = new()
             {
                 { StructureSelectionMapping.STRUCTURE_ID, typeof(string)},
@@ -165,32 +163,20 @@ public class ShapefileLoader
 
             double found_ht = row.TryGetValueAs<double>(map.FoundationHeightCol, DEFAULT_MISSING_NUMBER_VALUE);
             double ground_elv = updateGroundElevFromTerrain ? groundelevs[i] : row.TryGetValueAs<double>(map.GroundElevCol, DEFAULT_MISSING_NUMBER_VALUE);
-            double ff_elev = row.TryGetValueAs<double>(map.FirstFloorElevCol, DEFAULT_MISSING_NUMBER_VALUE);
-            if (ff_elev == DEFAULT_MISSING_NUMBER_VALUE)
-            {
-                ff_elev = ground_elv + found_ht;
-            }
+            double ff_elev = row.TryGetValueAs<double>(map.FirstFloorElevCol, ground_elv + found_ht);
 
             // Optional parameters:
             double val_cont = row.TryGetValueAs<double>(map.ContentValueCol, 0);
             double val_vehic = row.TryGetValueAs<double>(map.VehicleValueCol, 0);
             double val_other = row.TryGetValueAs<double>(map.OtherValueCol, 0);
             string cbfips = DEFAULT_MISSING_STRING_VALUE;
-
-            double beginningDamage = row.TryGetValueAs<double>(map.BeginningDamageDepthCol, DEFAULT_MISSING_NUMBER_VALUE);
-            if (beginningDamage == DEFAULT_MISSING_NUMBER_VALUE)
-            {
-                if (found_ht != DEFAULT_MISSING_NUMBER_VALUE)
-                    beginningDamage = -found_ht;
-            }
-
+            double beginningDamage = row.TryGetValueAs<double>(map.BeginningDamageDepthCol, -found_ht);
             int numStructures = row.TryGetValueAs<int>(map.NumberOfStructuresCol, 1);
             int yearInService = row.TryGetValueAs<int>(map.YearInConstructionCol, DEFAULT_MISSING_NUMBER_VALUE);
 
             // Get the point geometry from the feature.
             Geospatial.Vectors.Point point = structurePoints[i];
             int impactAreaID = GetImpactAreaFID(point, impactAreaCollection);
-
             string notes = row.TryGetValueAs<string>(map.NotesCol, DEFAULT_MISSING_STRING_VALUE).Trim();
             string description = row.TryGetValueAs<string>(map.DescriptionCol, DEFAULT_MISSING_STRING_VALUE).Trim();
 

--- a/HEC.FDA.Model/Spatial/StructureFactory.cs
+++ b/HEC.FDA.Model/Spatial/StructureFactory.cs
@@ -14,7 +14,7 @@ using Utility.Memory;
 using HEC.FDA.Model.Spatial.Extensions;
 
 namespace HEC.FDA.Model.Spatial;
-public class ShapefileLoader
+public class StructureFactory
 {
     private const string DEFAULT_MISSING_STRING_VALUE = "EMPTY";
     private const int DEFAULT_MISSING_NUMBER_VALUE = IntegerGlobalConstants.DEFAULT_MISSING_VALUE;
@@ -41,97 +41,20 @@ public class ShapefileLoader
         get { return _expectedTypes; }
     }
 
-    //[Obsolete("This method is deprecated. Use UpdatedLoadStructuresFromSourceFiles instead.")]
-    //public static List<Structure> LoadStructuresFromSourceFiles(string pointShapefilePath, StructureSelectionMapping map, string terrrainFilePath, bool updateGroundElevFromTerrain,
-    //        string impactAreaShapefilePath, Projection studyProjection, Dictionary<string, OccupancyType> occTypes)
-    //{
-    //    List<Structure> Structures = [];
-    //    PolygonFeatureLayer impactAreaFeatureLayer = new(UNUSED_STRING_VALUE, impactAreaShapefilePath);
-    //    List<Polygon> impactAreas = RASHelper.LoadImpactAreasFromSourceFiles(impactAreaFeatureLayer, studyProjection);
-    //    float[] groundelevs = Array.Empty<float>();
-    //    PointFeatureLayer structureFeatureLayer = new(UNUSED_STRING_VALUE, pointShapefilePath);
-    //    PointMs pointMs = new(structureFeatureLayer.Points().Select(p => p.PointM()));
-
-    //    //reproject right here. SI gets put into study projection immediately. 
-    //    Projection siProjection = RASHelper.GetVectorProjection(pointShapefilePath);
-    //    pointMs = RASHelper.ReprojectPoints(studyProjection, siProjection, pointMs);
-
-    //    if (updateGroundElevFromTerrain)
-    //    {
-    //        groundelevs = RASHelper.SamplePointsFromRaster(pointMs, terrrainFilePath);
-    //    }
-
-    //    for (int i = 0; i < structureFeatureLayer.FeatureCount(); i++)
-    //    {
-    //        //required parameters
-    //        PointM point = pointMs[i];
-    //        System.Data.DataRow row = structureFeatureLayer.FeatureRow(i);
-    //        string fid = GetFID(map, row);
-    //        double val_struct = RASHelper.GetRowValueForColumn<double>(row, map.StructureValueCol, DEFAULT_MISSING_NUMBER_VALUE);
-    //        string occtype = RASHelper.GetRowValueForColumn(row, map.OccTypeCol, DEFAULT_MISSING_STRING_VALUE);
-    //        string st_damcat = DEFAULT_MISSING_STRING_VALUE;
-    //        if (occTypes.ContainsKey(occtype))
-    //        {
-    //            st_damcat = occTypes[occtype].DamageCategory;
-    //            occtype = occTypes[occtype].Name;
-    //        }
-    //        //semi-required. We'll either have ff_elev given to us, or both ground elev and found_ht
-    //        double found_ht = RASHelper.GetRowValueForColumn<double>(row, map.FoundationHeightCol, DEFAULT_MISSING_NUMBER_VALUE); //not gauranteed
-    //        double ground_elv;
-    //        if (updateGroundElevFromTerrain)
-    //        {
-    //            ground_elv = groundelevs[i];
-    //        }
-    //        else
-    //        {
-    //            ground_elv = RASHelper.GetRowValueForColumn<double>(row, map.GroundElevCol, DEFAULT_MISSING_NUMBER_VALUE); //not gauranteed
-    //        }
-    //        double ff_elev = RASHelper.GetRowValueForColumn<double>(row, map.FirstFloorElevCol, DEFAULT_MISSING_NUMBER_VALUE); // not gauranteed  
-    //        if (ff_elev == DEFAULT_MISSING_NUMBER_VALUE)
-    //        {
-    //            ff_elev = ground_elv + found_ht;
-    //        }
-    //        //optional parameters
-    //        double val_cont = RASHelper.GetRowValueForColumn<double>(row, map.ContentValueCol, 0);
-    //        double val_vehic = RASHelper.GetRowValueForColumn<double>(row, map.VehicleValueCol, 0);
-    //        double val_other = RASHelper.GetRowValueForColumn<double>(row, map.OtherValueCol, 0);
-    //        string cbfips = DEFAULT_MISSING_STRING_VALUE;
-    //        double beginningDamage = RASHelper.GetRowValueForColumn<double>(row, map.BeginningDamageDepthCol, DEFAULT_MISSING_NUMBER_VALUE);
-    //        if (beginningDamage == DEFAULT_MISSING_NUMBER_VALUE)
-    //        {
-    //            if (found_ht != DEFAULT_MISSING_NUMBER_VALUE)
-    //            {
-    //                beginningDamage = -found_ht;
-    //            }
-    //        }
-    //        int numStructures = RASHelper.GetRowValueForColumn(row, map.NumberOfStructuresCol, 1);
-    //        int yearInService = RASHelper.GetRowValueForColumn(row, map.YearInConstructionCol, DEFAULT_MISSING_NUMBER_VALUE);
-    //        //TODO: handle number 
-    //        int impactAreaID = GetImpactAreaFID(point, impactAreas);
-    //        string notes = RASHelper.GetRowValueForColumn(row, map.NotesCol, DEFAULT_MISSING_STRING_VALUE);
-    //        string description = RASHelper.GetRowValueForColumn(row, map.DescriptionCol, DEFAULT_MISSING_STRING_VALUE);
-    //        Structures.Add(new Structure(fid, point, ff_elev, val_struct, st_damcat, occtype, impactAreaID, val_cont,
-    //            val_vehic, val_other, cbfips, beginningDamage, ground_elv, found_ht, yearInService, numStructures, notes, description));
-    //    }
-    //    return Structures;
-    //}
-
-
-
     public static OperationResult LoadStructuresFromSourceFiles(string pointShapefilePath, StructureSelectionMapping map, string terrrainFilePath, bool updateGroundElevFromTerrain,
             string impactAreaShapefilePath, Projection studyProjection, Dictionary<string, OccupancyType> occTypes, out List<Structure> structures)
     {
         structures = [];
 
         // 1. Read the Impact Area shapefile (polygons) 
-        OperationResult impactResult = ShapefileWriter.TryReadShapefile(impactAreaShapefilePath, out PolygonFeatureCollection impactAreaCollection, studyProjection);
+        OperationResult impactResult = ShapefileIO.TryRead(impactAreaShapefilePath, out PolygonFeatureCollection impactAreaCollection, studyProjection);
         if (!impactResult.Result)
         {
             return impactResult;
         }
 
         // 2. Read the structure shapefile (points)
-        OperationResult pointResult = ShapefileWriter.TryReadShapefile(pointShapefilePath, out PointFeatureCollection structurePoints, studyProjection);
+        OperationResult pointResult = ShapefileIO.TryRead(pointShapefilePath, out PointFeatureCollection structurePoints, studyProjection);
         if (!pointResult.Result)
         {
             return impactResult;
@@ -198,9 +121,6 @@ public class ShapefileLoader
     /// <summary>
     /// FID is commonly either string or int. This method will allow us to accept both. Tries to get string, if it fails, tries to get int. If it fails again, returns a default missing string value. 
     /// </summary>
-    /// <param name="map"></param>
-    /// <param name="row"></param>
-    /// <returns></returns>
     private static string GetFID(StructureSelectionMapping map, TableRow row)
     {
         string name = row.TryGetValueAs(map.StructureIDCol, DEFAULT_MISSING_STRING_VALUE);

--- a/HEC.FDA.Model/structures/Inventory.cs
+++ b/HEC.FDA.Model/structures/Inventory.cs
@@ -11,6 +11,7 @@ using HEC.MVVMFramework.Base.Events;
 using HEC.MVVMFramework.Base.Implementations;
 using HEC.FDA.Model.Spatial;
 using Statistics;
+using Utility.Logging;
 
 namespace HEC.FDA.Model.structures
 {
@@ -40,8 +41,16 @@ namespace HEC.FDA.Model.structures
         {
             OccTypes = occTypes;
             PriceIndex = priceIndex;
-            Projection studyProjection = Projection.FromFile(projectionFilePath);//Projection.FromFile returns Null if the path is bad. We'll check for null before we reproject. 
-            Structures = ShapefileLoader.LoadStructuresFromSourceFiles(pointShapefilePath, map, null, false, impactAreaShapefilePath, studyProjection, OccTypes);
+            Projection studyProjection = Projection.FromFile(projectionFilePath);//Projection.FromFile returns Null if the path is bad. We'll check for null before we reproject.
+            OperationResult operationResult = ShapefileLoader.LoadStructuresFromSourceFiles(pointShapefilePath, map, null, false, impactAreaShapefilePath, studyProjection, OccTypes, out List<Structure> structures);
+            if (operationResult.Result)
+            {
+                Structures = structures;
+            }
+            else
+            {
+                throw new Exception("Error loading structures from shapefiles" + operationResult.GetConcatenatedMessages());
+            }
         }
 
         /// <summary>
@@ -59,8 +68,15 @@ namespace HEC.FDA.Model.structures
             OccTypes = occTypes;
             PriceIndex = priceIndex;
             Projection studyProjection = RASHelper.GetProjectionFromTerrain(terrainPath);
-            Structures = ShapefileLoader.LoadStructuresFromSourceFiles(pointShapefilePath, map, terrainPath, true, impactAreaShapefilePath, studyProjection, OccTypes);
-
+            OperationResult operationResult = ShapefileLoader.LoadStructuresFromSourceFiles(pointShapefilePath, map, terrainPath, true, impactAreaShapefilePath, studyProjection, OccTypes, out List<Structure> structures);
+            if (operationResult.Result)
+            {
+                Structures = structures;
+            }
+            else
+            {
+                throw new Exception("Error loading structures from shapefiles" + operationResult.GetConcatenatedMessages());
+            }
         }
 
         /// <summary>

--- a/HEC.FDA.Model/structures/Inventory.cs
+++ b/HEC.FDA.Model/structures/Inventory.cs
@@ -42,7 +42,7 @@ namespace HEC.FDA.Model.structures
             OccTypes = occTypes;
             PriceIndex = priceIndex;
             Projection studyProjection = Projection.FromFile(projectionFilePath);//Projection.FromFile returns Null if the path is bad. We'll check for null before we reproject.
-            OperationResult operationResult = ShapefileLoader.LoadStructuresFromSourceFiles(pointShapefilePath, map, null, false, impactAreaShapefilePath, studyProjection, OccTypes, out List<Structure> structures);
+            OperationResult operationResult = StructureFactory.LoadStructuresFromSourceFiles(pointShapefilePath, map, null, false, impactAreaShapefilePath, studyProjection, OccTypes, out List<Structure> structures);
             if (operationResult.Result)
             {
                 Structures = structures;
@@ -68,7 +68,7 @@ namespace HEC.FDA.Model.structures
             OccTypes = occTypes;
             PriceIndex = priceIndex;
             Projection studyProjection = RASHelper.GetProjectionFromTerrain(terrainPath);
-            OperationResult operationResult = ShapefileLoader.LoadStructuresFromSourceFiles(pointShapefilePath, map, terrainPath, true, impactAreaShapefilePath, studyProjection, OccTypes, out List<Structure> structures);
+            OperationResult operationResult = StructureFactory.LoadStructuresFromSourceFiles(pointShapefilePath, map, terrainPath, true, impactAreaShapefilePath, studyProjection, OccTypes, out List<Structure> structures);
             if (operationResult.Result)
             {
                 Structures = structures;

--- a/HEC.FDA.Model/structures/Inventory.cs
+++ b/HEC.FDA.Model/structures/Inventory.cs
@@ -75,7 +75,7 @@ namespace HEC.FDA.Model.structures
             }
             else
             {
-                throw new Exception("Error loading structures from shapefiles" + operationResult.GetConcatenatedMessages());
+                throw new Exception("Error loading structures from shapefiles: " + operationResult.GetConcatenatedMessages());
             }
         }
 

--- a/HEC.FDA.Model/structures/Structure.cs
+++ b/HEC.FDA.Model/structures/Structure.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System;
 using HEC.FDA.Model.paireddata;
 using Geospatial.Vectors;
+using RasMapperLib.Utilities;
+using Math = System.Math;
 
 namespace HEC.FDA.Model.structures
 {
@@ -16,7 +18,7 @@ namespace HEC.FDA.Model.structures
         //TODO: How are we going to handle missing data?
         //For now, we won't allow missing data 
         public string Fid { get; }
-        public Geospatial.Vectors.Point Point { get; set; }
+        public PointM Point { get; set; }
         public double FirstFloorElevation { get; }
         public double GroundElevation { get; }
         public double InventoriedStructureValue { get; }
@@ -41,22 +43,41 @@ namespace HEC.FDA.Model.structures
 
         #region Constructors 
         /// <summary>
-        /// Maintained to support point M. No longer using PointMs behind the scene. 
+        /// Maintained to support point M.
         /// </summary>
         public Structure(string fid, PointM point, double firstFloorElevation, double val_struct, string st_damcat, string occtype, int impactAreaID, double val_cont =0, double val_vehic = 0, double val_other = 0, 
             string cbfips = "unassigned", double beginDamage = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, double groundElevation = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE,
             double foundationHeight = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, int year = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, int numStructures = 1, string notes = "", string description = "")
         {
-            Geospatial.Vectors.Point geoPoint = RasMapperLib.Utilities.Converter.Convert(point);
-            return new Structure(fid, geoPoint, firstFloorElevation, val_struct, st_damcat, occtype, impactAreaID, val_cont = 0, val_vehic = 0, val_other = 0, cbfips = "unassigned", beginDamage = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE,
-                 groundElevation = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, foundationHeight = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, year = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, numStructures = 1,
-                 notes = "", description = "");
+            Fid = fid;
+            Point = point;
+            InventoriedStructureValue = val_struct;
+            InventoriedContentValue = val_cont;
+            InventoriedVehicleValue = val_vehic;
+            InventoriedOtherValue = val_other;
+            DamageCatagory = st_damcat;
+            OccTypeName = occtype;
+            ImpactAreaID = impactAreaID;
+            Cbfips = cbfips;
+            FirstFloorElevation = firstFloorElevation;
+            GroundElevation = groundElevation;
+            FoundationHeight = foundationHeight;
+            YearInService = year;
+            NumberOfStructures = numStructures;
+            BeginningDamageDepth = beginDamage;
+            AddRules();
+            Notes = notes;
+            Description = description;
         }
+        /// <summary>
+        /// Preferred Constructor for now. Eventually will store Geospatial.Vectors.Point instead of PointM.
+        /// </summary>
         public Structure(string fid, Geospatial.Vectors.Point point, double firstFloorElevation, double val_struct, string st_damcat, string occtype, int impactAreaID, double val_cont = 0, double val_vehic = 0, double val_other = 0, string cbfips = "unassigned", double beginDamage = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, double groundElevation = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, double foundationHeight = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, int year = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, int numStructures = 1, string notes = "", string description = "")
 
         {
             Fid = fid;
-            Point = point;
+            PointM pt = Converter.ConvertPtM(point);
+            Point = pt;
             InventoriedStructureValue = val_struct;
             InventoriedContentValue = val_cont;
             InventoriedVehicleValue = val_vehic;

--- a/HEC.FDA.Model/structures/Structure.cs
+++ b/HEC.FDA.Model/structures/Structure.cs
@@ -5,6 +5,7 @@ using HEC.FDA.Model.metrics;
 using System.Collections.Generic;
 using System;
 using HEC.FDA.Model.paireddata;
+using Geospatial.Vectors;
 
 namespace HEC.FDA.Model.structures
 {
@@ -15,7 +16,7 @@ namespace HEC.FDA.Model.structures
         //TODO: How are we going to handle missing data?
         //For now, we won't allow missing data 
         public string Fid { get; }
-        public PointM Point { get; set; }
+        public Geospatial.Vectors.Point Point { get; set; }
         public double FirstFloorElevation { get; }
         public double GroundElevation { get; }
         public double InventoriedStructureValue { get; }
@@ -39,7 +40,19 @@ namespace HEC.FDA.Model.structures
         #endregion
 
         #region Constructors 
-        public Structure(string fid, PointM point, double firstFloorElevation, double val_struct, string st_damcat, string occtype, int impactAreaID, double val_cont =0, double val_vehic = 0, double val_other = 0, string cbfips = "unassigned", double beginDamage = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, double groundElevation = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, double foundationHeight = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, int year = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, int numStructures = 1, string notes = "", string description = "")
+        /// <summary>
+        /// Maintained to support point M. No longer using PointMs behind the scene. 
+        /// </summary>
+        public Structure(string fid, PointM point, double firstFloorElevation, double val_struct, string st_damcat, string occtype, int impactAreaID, double val_cont =0, double val_vehic = 0, double val_other = 0, 
+            string cbfips = "unassigned", double beginDamage = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, double groundElevation = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE,
+            double foundationHeight = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, int year = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, int numStructures = 1, string notes = "", string description = "")
+        {
+            Geospatial.Vectors.Point geoPoint = RasMapperLib.Utilities.Converter.Convert(point);
+            return new Structure(fid, geoPoint, firstFloorElevation, val_struct, st_damcat, occtype, impactAreaID, val_cont = 0, val_vehic = 0, val_other = 0, cbfips = "unassigned", beginDamage = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE,
+                 groundElevation = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, foundationHeight = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, year = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, numStructures = 1,
+                 notes = "", description = "");
+        }
+        public Structure(string fid, Geospatial.Vectors.Point point, double firstFloorElevation, double val_struct, string st_damcat, string occtype, int impactAreaID, double val_cont = 0, double val_vehic = 0, double val_other = 0, string cbfips = "unassigned", double beginDamage = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, double groundElevation = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, double foundationHeight = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, int year = utilities.IntegerGlobalConstants.DEFAULT_MISSING_VALUE, int numStructures = 1, string notes = "", string description = "")
 
         {
             Fid = fid;

--- a/HEC.FDA.ModelTest/unittests/hydraulics/HydraulicProfileShould.cs
+++ b/HEC.FDA.ModelTest/unittests/hydraulics/HydraulicProfileShould.cs
@@ -41,8 +41,8 @@ namespace HEC.FDA.ModelTest.unittests.hydraulics
         {
             StructureSelectionMapping map = new StructureSelectionMapping(false, false, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
             HydraulicProfile profile = new HydraulicProfile(.01, fileName, profileName);
-            OccupancyType occupancyType = OccupancyType.Builder().Build();
-            Dictionary<string, OccupancyType> occupancyTypes = new Dictionary<string, OccupancyType>() { { "occtype", occupancyType } };
+            OccupancyType occupancyType = OccupancyType.Builder().WithName("EMPTY").WithDamageCategory("Test").Build(); // need to at least give it a name, and a damage catagory because the structures we create for the inventory store those directly. Should reconsder this for future designs. 
+            Dictionary<string, OccupancyType> occupancyTypes = new Dictionary<string, OccupancyType>() { { "EMPTY", occupancyType } };
 
             Inventory inventory;
             if(useTerrainFile)

--- a/HEC.FDA.ModelTest/unittests/structures/InventoryShould.cs
+++ b/HEC.FDA.ModelTest/unittests/structures/InventoryShould.cs
@@ -47,7 +47,12 @@ namespace HEC.FDA.ModelTest.unittests.structures
                 GroundElevCol,ContentValueCol,OtherValueCol,VehicleValueCol,BeginningDamageDepthCol,YearInConstructionCol,NotesCol,DescriptionCol,NumberOfStructuresCol);
             //Empty (default) occupancy types
             OccupancyType occupancyType = OccupancyType.Builder().Build();
-            Dictionary<string, OccupancyType> occupancyTypes = new Dictionary<string, OccupancyType>() { { "occtype", occupancyType } };
+
+            //This is a hack to make every occtype string match the same key.
+            Dictionary<string, OccupancyType> occupancyTypes = new Dictionary<string, OccupancyType>(new CustomEqualityComparer())
+            {
+                { "EMPTY", occupancyType }
+            };
             Inventory inv;
             if (useTerrainFile)
             {
@@ -119,6 +124,22 @@ namespace HEC.FDA.ModelTest.unittests.structures
             PointM newPnt = RASHelper.ReprojectPoint(pnt, projTerr, projPnt);
             //Assert
             Assert.NotEqual(pnt.X, newPnt.X);
+        }
+    }
+
+    /// <summary>
+    /// Used to make all string match the same key in the dictionary above. Super Hacky. DO NOT USE ANYWHERE OUTSIDE THIS CLASS. 
+    /// </summary>
+    internal class CustomEqualityComparer : IEqualityComparer<string>
+    {
+        public bool Equals(string x, string y)
+        {
+            return true; // Always return true to make all keys equal
+        }
+
+        public int GetHashCode(string obj)
+        {
+            return 0; // Return a constant hash code for all keys
         }
     }
 }

--- a/HEC.FDA.View/FrequencyRelationships/FrequencyEditor/GraphicalControl.xaml
+++ b/HEC.FDA.View/FrequencyRelationships/FrequencyEditor/GraphicalControl.xaml
@@ -42,6 +42,6 @@
                    GroupName="{Binding InstanceID, RelativeSource={RelativeSource AncestorType=UserControl}}"
                    x:Name="StageRadioButton"/>
         </StackPanel>
-        <local:FdaDataGridControl DataContext="{Binding Path =SelectedItem }" Grid.Row="3"/>
+        <local:FdaDataGridControl DataContext="{Binding Path =SelectedItem }" UseStarSizing="True"  Grid.Row="3"/>
     </Grid>
 </UserControl>

--- a/HEC.FDA.View/FrequencyRelationships/FrequencyEditor/ParameterEntryControl.xaml
+++ b/HEC.FDA.View/FrequencyRelationships/FrequencyEditor/ParameterEntryControl.xaml
@@ -9,46 +9,46 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
              d:Background="AliceBlue"  d:DataContext="{d:DesignInstance Type=FEvm:ParameterEntryVM}">
-  <Grid>
-    <Grid.ColumnDefinitions>
-      <ColumnDefinition/>
-      <ColumnDefinition/>
-    </Grid.ColumnDefinitions>
-    
-    <!--Parameters Input Q2-->
-    <Grid Grid.Row="0" Grid.Column="0" Visibility="Visible">
-      <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="120"/>
-        <ColumnDefinition Width="80*"/>
-      </Grid.ColumnDefinitions>
-      <Grid.RowDefinitions>
-        <RowDefinition Height="35"/>
-        <RowDefinition Height="35"/>
-        <RowDefinition Height="35"/>
-        <RowDefinition Height="35"/>
-        <RowDefinition Height="25"/> <!--Table Header Row--> 
-        <RowDefinition Height="*"/>
-      </Grid.RowDefinitions>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
 
-      <Label Grid.Row="0" Content="Mean:" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-      <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Mean, ValidatesOnDataErrors=True, TargetNullValue=''}" Margin="5"/>
-      <Label Grid.Row="1"  Content="Standard Deviation:" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-      <TextBox Grid.Row="1"  Grid.Column="1" Text="{Binding Standard_Deviation, ValidatesOnDataErrors=True}" Margin="5"/>
-      <Label Grid.Row="2"  Content="Skew:" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-      <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Skew, ValidatesOnDataErrors=True}" Margin="5"/>
-      <Label Grid.Row="3" Content="Record Length:" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-      <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding SampleSize, ValidatesOnDataErrors=True}" Margin="5"/>
-     
-      <!--Tabulated Relationship Q3-->
-        <TextBlock Grid.Row="4" Margin="5" Grid.ColumnSpan="2">
+        <!--Parameters Input Q2-->
+        <Grid Grid.Row="0" Grid.Column="0" Visibility="Visible">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="120"/>
+                <ColumnDefinition Width="80*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="35"/>
+                <RowDefinition Height="35"/>
+                <RowDefinition Height="35"/>
+                <RowDefinition Height="35"/>
+        <RowDefinition Height="25"/> <!--Table Header Row--> 
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <Label Grid.Row="0" Content="Mean:" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Mean, ValidatesOnDataErrors=True, TargetNullValue=''}" Margin="5"/>
+            <Label Grid.Row="1"  Content="Standard Deviation:" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="1"  Grid.Column="1" Text="{Binding Standard_Deviation, ValidatesOnDataErrors=True}" Margin="5"/>
+            <Label Grid.Row="2"  Content="Skew:" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Skew, ValidatesOnDataErrors=True}" Margin="5"/>
+            <Label Grid.Row="3" Content="Record Length:" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding SampleSize, ValidatesOnDataErrors=True}" Margin="5"/>
+
+            <!--Tabulated Relationship Q3-->
+            <TextBlock Grid.Row="4" Margin="5" Grid.ColumnSpan="2">
           <Run Text="Analytical Frequency " FontWeight="Bold"/>
           <Run Text="(Exceedence Probability, Discharge)"/>
-        </TextBlock>
-            <tablewithplot:FdaDataGridControl DataContext="{Binding Path=ConfidenceLimitsDataTable }" Grid.Row="5" Grid.ColumnSpan="2"  Margin="10"/>
+            </TextBlock>
+            <tablewithplot:FdaDataGridControl DataContext="{Binding Path=ConfidenceLimitsDataTable }" UseStarSizing="True" Grid.Row="5" Grid.ColumnSpan="2"  Margin="10"/>
+        </Grid>
+
+        <!--Plot Q1 and Q4-->
+        <oxy:PlotView Model="{Binding Path= PlotModel}" Grid.Column="1"/>
+
     </Grid>
-
-    <!--Plot Q1 and Q4-->
-    <oxy:PlotView Model="{Binding Path= PlotModel}" Grid.Column="1"/>
-
-  </Grid>
 </UserControl>

--- a/HEC.FDA.View/TableWithPlot/ComputeComponentControl.xaml
+++ b/HEC.FDA.View/TableWithPlot/ComputeComponentControl.xaml
@@ -16,6 +16,6 @@
             <ComboBox Margin="5" ItemsSource="{Binding Path = Options}" Grid.Column="1" SelectedItem="{Binding Path=SelectedItem}" DisplayMemberPath="Name"/>
             <Label Content="{Binding Path=Units}" VerticalAlignment="Center"/>
         </StackPanel>
-        <local:FdaDataGridControl DataContext="{Binding Path=SelectedItem }" Grid.Row="1"/>
+        <local:FdaDataGridControl DataContext="{Binding Path=SelectedItem }" UseStarSizing="True" Grid.Row="1"/>
     </Grid>
 </UserControl>

--- a/HEC.FDA.View/TableWithPlot/FdaDataGrid.cs
+++ b/HEC.FDA.View/TableWithPlot/FdaDataGrid.cs
@@ -29,6 +29,15 @@ namespace HEC.FDA.View.TableWithPlot
 
         public bool AllowAddDeleteRows { get; set; } = true;
         public bool PasteAddsRows { get; set; } = true;
+        //Dependency property to control the column sizing behavior.
+        public static readonly DependencyProperty UseStarSizingProperty = DependencyProperty.Register("UseStarSizing", typeof(bool), typeof(FdaDataGrid), new PropertyMetadata(false));
+
+        public bool UseStarSizing
+        {
+            get { return (bool)GetValue(UseStarSizingProperty); }
+            set { SetValue(UseStarSizingProperty, value); }
+        }
+
         public FdaDataGrid()
         {
             //TODO:  This might be bad, I never remove these handlers, but I don't know how to do it better. 
@@ -457,8 +466,15 @@ namespace HEC.FDA.View.TableWithPlot
                 }
                 e.Cancel = cancel;
                 if (cancel) { return; }
-
-                dataGridtextColumn.Width = new DataGridLength(1, DataGridLengthUnitType.Auto);
+                // Only override the width if UseStarSizing is true.
+                if (UseStarSizing)
+                {
+                    dataGridtextColumn.Width = new DataGridLength(1, DataGridLengthUnitType.Star);
+                }
+                else
+                {
+                    dataGridtextColumn.Width = new DataGridLength(1, DataGridLengthUnitType.Auto);
+            }
                 Style ers = (Style)Resources["errorStyle"];
                 Style ersG = (Style)Resources["errorStyleGrid"];
                 dataGridtextColumn.EditingElementStyle = ers;

--- a/HEC.FDA.View/TableWithPlot/FdaDataGridControl.xaml.cs
+++ b/HEC.FDA.View/TableWithPlot/FdaDataGridControl.xaml.cs
@@ -11,6 +11,38 @@ namespace HEC.FDA.View.TableWithPlot
     /// </summary>
     public partial class FdaDataGridControl : UserControl
     {
+        // Register a dependency property so that users outside can set this property.
+        public static readonly DependencyProperty UseStarSizingProperty =
+            DependencyProperty.Register(
+                "UseStarSizing",
+                typeof(bool),
+                typeof(FdaDataGridControl),
+                new PropertyMetadata(false, OnUseStarSizingChanged));
+
+        public bool UseStarSizing
+        {
+            get { return (bool)GetValue(UseStarSizingProperty); }
+            set { SetValue(UseStarSizingProperty, value); }
+        }
+
+        private static void OnUseStarSizingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var control = d as FdaDataGridControl;
+            if (control != null)
+            {
+                control.UpdateInternalGridStarSizing((bool)e.NewValue);
+            }
+        }
+
+        private void UpdateInternalGridStarSizing(bool useStar)
+        {
+            // Assuming your FdaDataGrid in the XAML has the name "MyDataGrid"
+            if (MyDataGrid != null)
+            {
+                MyDataGrid.UseStarSizing = useStar;
+            }
+        }
+
         public FdaDataGridControl()
         {
             InitializeComponent();

--- a/HEC.FDA.ViewModel/AggregatedStageDamage/CalculatedStageDamageVM.cs
+++ b/HEC.FDA.ViewModel/AggregatedStageDamage/CalculatedStageDamageVM.cs
@@ -1,6 +1,5 @@
 ﻿using HEC.FDA.Model.paireddata;
 using HEC.FDA.Model.stageDamage;
-using HEC.FDA.Model.structures;
 using HEC.FDA.ViewModel.FlowTransforms;
 using HEC.FDA.ViewModel.FrequencyRelationships;
 using HEC.FDA.ViewModel.Hydraulics.GriddedData;
@@ -10,7 +9,6 @@ using HEC.FDA.ViewModel.Saving;
 using HEC.FDA.ViewModel.StageTransforms;
 using HEC.FDA.ViewModel.TableWithPlot;
 using HEC.FDA.ViewModel.Utilities;
-using HEC.MVVMFramework.Model.Messaging;
 using SciChart.Core.Extensions;
 using System;
 using System.Collections.Generic;
@@ -620,7 +618,7 @@ namespace HEC.FDA.ViewModel.AggregatedStageDamage
                     List<string> errors = scenarioStageDamage.GetErrorMessages();
                     if (errors.Count > 0)
                     {
-                        MessageBox.Show("There are errors in the data used to compute stage-damage. See the errors file in the structure stage damage details folder of this study directory.", "Data Errors", MessageBoxButton.OK, MessageBoxImage.Warning);
+                        MessageBox.Show("There are errors in the data used to compute stage-damage. See the errors file in the structure stage damage details folder of this study directory.", "Data Errors", MessageBoxButton.OK, MessageBoxImage.Information);
                     }
                     else
                     {

--- a/HEC.FDA.ViewModel/Alternatives/AlternativeElement.cs
+++ b/HEC.FDA.ViewModel/Alternatives/AlternativeElement.cs
@@ -217,7 +217,7 @@ namespace HEC.FDA.ViewModel.Alternatives
             return altResult;
         }
 
-        public void ComputeAlternative(object arg1 = null, EventArgs arg2 = null)
+        public async void ComputeAlternative(object arg1 = null, EventArgs arg2 = null)
         {
             //This is the new entry point for the "view results" menu item
             //when the compute is completed it will call ComputeCompleted which will then call the "ViewResults".
@@ -227,21 +227,17 @@ namespace HEC.FDA.ViewModel.Alternatives
                 ISynchronizationContext context = new SynchronizationContext(action => Application.Current.Dispatcher.BeginInvoke(action));
                 BatchJob batchJob = new(uiThreadSyncContext: context);
                 ComputeAlternativeVM vm = new(batchJob);
-                ComputeAlternativeVM.RunAnnualizationCompute(this, ComputeCompleted,batchJob.Reporter);
                 string header = "Compute Log For Alternative: " + Name;
                 DynamicTabVM tab = new(header, vm, "ComputeLog" + Name);
                 Navigate(tab, false, false);
+                Results = await ComputeAlternativeVM.RunAnnualizationCompute(this, batchJob.Reporter);
+                ViewResults();
+
             }
             else
             {
                 MessageBox.Show(vr.ErrorMessage, "Cannot Compute Alternative Results", MessageBoxButton.OK, MessageBoxImage.Exclamation);
             }
-        }
-
-        private void ComputeCompleted(AlternativeResults results)
-        {
-            Results = results;
-            Application.Current.Dispatcher.Invoke(() => { ViewResults();});
         }
 
         private void ViewResults()

--- a/HEC.FDA.ViewModel/Alternatives/AlternativeElement.cs
+++ b/HEC.FDA.ViewModel/Alternatives/AlternativeElement.cs
@@ -224,7 +224,7 @@ namespace HEC.FDA.ViewModel.Alternatives
                 ProgressReporter reporter = new();
                 BatchJob batchJob = new(reporter);
                 ComputeAlternativeVM vm = new ComputeAlternativeVM(batchJob);
-                ComputeAlternativeVM.RunAnnualizationCompute(this, ComputeCompleted, reporter);
+                ComputeAlternativeVM.RunAnnualizationCompute(this, ComputeCompleted);
                 string header = "Compute Log For Alternative: " + Name;
                 DynamicTabVM tab = new(header, vm, "ComputeLog" + Name);
                 Navigate(tab, false, false);

--- a/HEC.FDA.ViewModel/HEC.FDA.ViewModel.csproj
+++ b/HEC.FDA.ViewModel/HEC.FDA.ViewModel.csproj
@@ -13,7 +13,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-		<PackageReference Include="HEC.RAS.Visual.Observables" Version="0.1.0.1421-dev" />		
+		<PackageReference Include="HEC.RAS.Visual.Observables" Version="0.1.0.1554-dev" />		
 		<PackageReference Include="PlottingLibrary2D" Version="1.0.0-beta-gdc08aa8621" />
 		<PackageReference Include="OxyPlot.Wpf" Version="2.1.2" />
 	</ItemGroup>

--- a/HEC.FDA.ViewModel/Inventory/ImportStructuresFromShapefileVM.cs
+++ b/HEC.FDA.ViewModel/Inventory/ImportStructuresFromShapefileVM.cs
@@ -243,7 +243,7 @@ namespace HEC.FDA.ViewModel.Inventory
             }
             string fieldName = rowItem.Name;
             string shapefileColumnName = rowItem.SelectedItem;
-            Type expectedType = ShapefileLoader.ExpectedTypes[fieldName];
+            Type expectedType = StructureFactory.ExpectedTypes[fieldName];
             Type actualType = siPointLayerTable.Columns[shapefileColumnName].DataType;
 
             //this short circuits and lets FID be either int or string. it's handled in the importer. 

--- a/HEC.FDA.ViewModel/Inventory/InventoryOcctypeLinkingVM.cs
+++ b/HEC.FDA.ViewModel/Inventory/InventoryOcctypeLinkingVM.cs
@@ -237,7 +237,7 @@ namespace HEC.FDA.ViewModel.Inventory
         {
             HashSet<string> uniqueList = new();
             PointFeatureCollection collection;
-            OperationResult res = ShapefileWriter.TryReadShapefile(_Path, out collection);
+            OperationResult res = ShapefileIO.TryRead(_Path, out collection);
             if (res.Result)
             {
                 TableColumn occTypeColumn = collection.AttributeTable.GetColumn(_SelectedOcctypeName);

--- a/HEC.FDA.ViewModelTest/HEC.FDA.ViewModelTest.csproj
+++ b/HEC.FDA.ViewModelTest/HEC.FDA.ViewModelTest.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="HEC.RAS.Ras.Mapper" Version="0.1.0.1421-dev" />
+		<PackageReference Include="HEC.RAS.Ras.Mapper" Version="0.1.0.1506-dev" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0-release-24373-02" />
 		<PackageReference Include="xunit" Version="2.8.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">

--- a/HEC.FDA.ViewModelTest/HEC.FDA.ViewModelTest.csproj
+++ b/HEC.FDA.ViewModelTest/HEC.FDA.ViewModelTest.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="HEC.RAS.Ras.Mapper" Version="0.1.0.1506-dev" />
+		<PackageReference Include="HEC.RAS.Ras.Mapper" Version="0.1.0.1554-dev" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0-release-24373-02" />
 		<PackageReference Include="xunit" Version="2.8.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">

--- a/ScratchSpace/EntryPoints/Beam.cs
+++ b/ScratchSpace/EntryPoints/Beam.cs
@@ -12,24 +12,24 @@ public static class Beam
     public static void EntryPoint()
     {
         GDALSetup.InitializeMultiplatform();
-        string tiff = @"C:\Temp\_FDA\MySAC38_FragTest\MySAC38_FragTest\Hydraulic Data\Grids\80\WSE80Pct.tif";
-        string structureInv = @"C:\Temp\_FDA\MySAC38_FragTest\MySAC38_FragTest\Structure Inventories\Structs\Structure.shp";
-        string impactArea = @"C:\Temp\_FDA\MySAC38_FragTest\MySAC38_FragTest\Impact Areas\IA\Sac38_Zone_10N.shp";
-        Projection tiffProj = RASHelper.GetProjectionFromTerrain(tiff);
-        Projection siProj = RASHelper.GetVectorProjection(structureInv);
-        Projection iaProj = RASHelper.GetVectorProjection(impactArea);
-        bool same = tiffProj.Equals(iaProj);
-        PolygonFeatureLayer ias = new("",impactArea);
-        PolygonFeatureCollection pgsOut = new();
-        ShapefileWriter.TryReadShapefile(impactArea,out pgsOut);
-        var gon = pgsOut.Features[0];
-        var reprogon = gon.Reproject(iaProj, tiffProj);
-        Console.WriteLine(gon);
-        Console.WriteLine(reprogon);
-        List<Polygon> polygons = ias.Polygons().ToList();
-        //This reprojection is incorrect and failing. Move shapefile reader. 
-        List<Polygon> reproPolys = RASHelper.ReprojectPolygons(tiffProj, polygons, iaProj);
-        Console.WriteLine("garbage");
+        //string tiff = @"C:\Temp\_FDA\MySAC38_FragTest\MySAC38_FragTest\Hydraulic Data\Grids\80\WSE80Pct.tif";
+        //string structureInv = @"C:\Temp\_FDA\MySAC38_FragTest\MySAC38_FragTest\Structure Inventories\Structs\Structure.shp";
+        //string impactArea = @"C:\Temp\_FDA\MySAC38_FragTest\MySAC38_FragTest\Impact Areas\IA\Sac38_Zone_10N.shp";
+        //Projection tiffProj = RASHelper.GetProjectionFromTerrain(tiff);
+        //Projection siProj = RASHelper.GetVectorProjection(structureInv);
+        //Projection iaProj = RASHelper.GetVectorProjection(impactArea);
+        //bool same = tiffProj.Equals(iaProj);
+        //PolygonFeatureLayer ias = new("",impactArea);
+        //PolygonFeatureCollection pgsOut = new();
+        //ShapefileWriter.TryReadShapefile(impactArea,out pgsOut);
+        //var gon = pgsOut.Features[0];
+        //var reprogon = gon.Reproject(iaProj, tiffProj);
+        //Console.WriteLine(gon);
+        //Console.WriteLine(reprogon);
+        //List<Polygon> polygons = ias.Polygons().ToList();
+        ////This reprojection is incorrect and failing. Move shapefile reader. 
+        //List<Polygon> reproPolys = RASHelper.ReprojectPolygons(tiffProj, polygons, iaProj);
+        //Console.WriteLine("garbage");
 
     }
 

--- a/ScratchSpace/ScratchSpace.csproj
+++ b/ScratchSpace/ScratchSpace.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HEC.RAS.Ras.Mapper" Version="0.1.0.1421-dev" />
+    <PackageReference Include="HEC.RAS.Ras.Mapper" Version="0.1.0.1506-dev" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ScratchSpace/ScratchSpace.csproj
+++ b/ScratchSpace/ScratchSpace.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HEC.RAS.Ras.Mapper" Version="0.1.0.1506-dev" />
+    <PackageReference Include="HEC.RAS.Ras.Mapper" Version="0.1.0.1554-dev" />
   </ItemGroup>
 
   <ItemGroup>

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<packageSources>
-		<clear/>
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
 		<add key="fda-nuget" value="https://www.hec.usace.army.mil/nexus/repository/fda-nuget/" />
 		<add key="dss-nuget" value="https://www.hec.usace.army.mil/nexus/repository/dss/" />


### PR DESCRIPTION
This update moves us largely off RasMapper for geospatial operations.  We do still use PointM as our coordinate for structures on construction. That's important because we need to work in old ras space (RasMapper) to use RAS6.x terrains and results. So everywhere we can, we're now sticking to the actively developed RAS2025 codebase and ways of doing things, and only reverting for operations we can't support. 

