### PR TITLE
Fix Copy Paste 

### DIFF
--- a/HEC.FDA.View/TableWithPlot/FdaDataGrid.cs
+++ b/HEC.FDA.View/TableWithPlot/FdaDataGrid.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Windows;
@@ -246,9 +247,17 @@ namespace HEC.FDA.View.TableWithPlot
 
             return UniqueRows;
         }
+
+        /// <summary>
+        /// The ApplicationCommands.Copy.Execute() stopped working properly at some point. This is a hack to get rid of all the different formats it copies and explicitly set only the one we want for pasting into excel.
+        /// </summary>
         private void CopyClipBoard(object sender, RoutedEventArgs e)
         {
             ApplicationCommands.Copy.Execute(null, this);
+            IDataObject clipboardData = Clipboard.GetDataObject();
+            object data = clipboardData.GetData("Text");
+            Clipboard.Clear();
+            Clipboard.SetText(data.ToString());
         }
         private void MenuItemPasteClipboard(object sender, RoutedEventArgs e)
         {


### PR DESCRIPTION
Address an issue where copying from a datagrid in FDA would not paste into Excel. I have not been able to track down when, or why this happened. "Copy" was handled by the System.Windows Library, not us. My best guess is that the behavior changed between Net 6.0 -< Net 9.0, but I have not yet found the commit where we changed, or found discussion on the webs. 

Nevertheless, this is a pretty clean fix as far as hacks go. Windows copies data in multiple formats when you call copy. I grab the data in "text" format, purge the clipboard, and set the text data back to the clipboard every copy, so the data we want for excel is the only data in there.

seems to work. 