### PR TITLE
1214 uncertainty around graphical stage frequency appears to be incorrect

### DIFF
--- a/HEC.FDA.Model/extensions/GraphicalDistribution.cs
+++ b/HEC.FDA.Model/extensions/GraphicalDistribution.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Statistics.Distributions;
+using Statistics;
 using HEC.MVVMFramework.Base.Enumerations;
 using HEC.MVVMFramework.Base.Implementations;
 using System.Xml.Linq;
@@ -9,7 +10,7 @@ using HEC.FDA.Model.utilities;
 using HEC.MVVMFramework.Base.Events;
 using HEC.MVVMFramework.Model.Messaging;
 
-namespace Statistics.GraphicalRelationships
+namespace HEC.FDA.Model.extensions
 {
     [StoredProperty("GraphicalDistribution")]
     public class GraphicalDistribution: ValidationErrorLogger
@@ -180,7 +181,7 @@ namespace Statistics.GraphicalRelationships
             //less frequent end of the frequency curve
             if (finalExceedanceProbabilities.Last() - minimumExceedanceProbability > toleratedDifference)
             {
-                Distributions.Normal standardNormalDistribution = new();
+                Normal standardNormalDistribution = new();
                 double penultimateInputExceedanceProbability = finalExceedanceProbabilities[^2];
                 double lastInputExceedanceProbability = finalExceedanceProbabilities.Last();
                 double zValueOfMin = standardNormalDistribution.InverseCDF(minimumExceedanceProbability);
@@ -321,7 +322,7 @@ namespace Statistics.GraphicalRelationships
             {
                 for (int i = 0; i < stageOrLogFlowStandardErrorsComputed.Length; i++)
                 {
-                    distributionArray[i] = new Distributions.Normal(StageOrLoggedFlowValues[i], stageOrLogFlowStandardErrorsComputed[i]);
+                    distributionArray[i] = new Normal(StageOrLoggedFlowValues[i], stageOrLogFlowStandardErrorsComputed[i]);
                 }
                 return distributionArray;
             }
@@ -329,7 +330,7 @@ namespace Statistics.GraphicalRelationships
             {
                 for (int i = 0; i < stageOrLogFlowStandardErrorsComputed.Length; i++)
                 {
-                    distributionArray[i] = new Distributions.LogNormal(StageOrLoggedFlowValues[i], stageOrLogFlowStandardErrorsComputed[i]);
+                    distributionArray[i] = new LogNormal(StageOrLoggedFlowValues[i], stageOrLogFlowStandardErrorsComputed[i]);
                 }
                 return distributionArray;
             }

--- a/HEC.FDA.Model/paireddata/GraphicalUncertainPairedData.cs
+++ b/HEC.FDA.Model/paireddata/GraphicalUncertainPairedData.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Statistics.GraphicalRelationships;
+using HEC.FDA.Model.extensions;
 using System.Xml.Linq;
 using System;
 using HEC.FDA.Model.interfaces;

--- a/HEC.FDA.Model/paireddata/GraphicalUncertainPairedData.cs
+++ b/HEC.FDA.Model/paireddata/GraphicalUncertainPairedData.cs
@@ -94,7 +94,14 @@ namespace HEC.FDA.Model.paireddata
             bool isMonotonicallyIncreasing = IsMonotonicallyIncreasing(pairedData);
             if (!isMonotonicallyIncreasing)
             {
-                pairedData.ForceStrictMonotonicity();
+                if (probability < 0.5)
+                {
+                    pairedData.ForceStrictMonotonicityBottomUp();
+
+                } else
+                {
+                    pairedData.ForceStrictMonotonicityTopDown();
+                }
             }
             double[] expandedStageOrLogFlowValues = InterpolateQuantiles.InterpolateOnX(pairedData.Xvals, CombinedExceedanceProbabilities, pairedData.Yvals);
             if (!GraphicalDistributionWithLessSimple.UsingStagesNotFlows)
@@ -147,7 +154,15 @@ namespace HEC.FDA.Model.paireddata
             bool isMonotonicallyIncreasing = IsMonotonicallyIncreasing(pairedData);
             if (!isMonotonicallyIncreasing)
             {
-                pairedData.ForceStrictMonotonicity();
+                if (probability < 0.5)
+                {
+                    pairedData.ForceStrictMonotonicityBottomUp();
+
+                }
+                else
+                {
+                    pairedData.ForceStrictMonotonicityTopDown();
+                }
             }
             double[] expandedStageOrLogFlowValues = InterpolateQuantiles.InterpolateOnX(pairedData.Xvals, CombinedExceedanceProbabilities, pairedData.Yvals);
             if (!GraphicalDistributionWithLessSimple.UsingStagesNotFlows)

--- a/HEC.FDA.Model/paireddata/InterpolateQuantiles.cs
+++ b/HEC.FDA.Model/paireddata/InterpolateQuantiles.cs
@@ -8,25 +8,25 @@ namespace Statistics.Graphical
         /// <summary>
         /// Interpolates on stage for flow for an expanded set of exceedance probabilities 
         /// </summary>
-        /// <param name="inputNonexceedanceProbabilities"></param> input non-exceedance probabilities 
+        /// <param name="inputExceedanceProbabilities"></param> input exceedance probabilities 
         /// <param name="exceedanceProbabilitiesForWhichQuantilesAreRequired"></param> non-exceedance probabilities at which to calculate stage or flow
         /// <param name="inputDataForInterpolation"></param> input stage or flow values
         /// <returns></returns>
-        public static double[] InterpolateOnX(double[] inputNonexceedanceProbabilities, double[] exceedanceProbabilitiesForWhichQuantilesAreRequired, double[] inputDataForInterpolation)
+        public static double[] InterpolateOnX(double[] inputExceedanceProbabilities, double[] exceedanceProbabilitiesForWhichQuantilesAreRequired, double[] inputDataForInterpolation)
         {
 
             Normal standardNormalDistribution = new();
-            double[] inputZs = new double[inputNonexceedanceProbabilities.Length];
-            for (int i = 0; i < inputNonexceedanceProbabilities.Length; i++)
+            double[] inputZs = new double[inputExceedanceProbabilities.Length];
+            for (int i = 0; i < inputExceedanceProbabilities.Length; i++)
             {
-                inputZs[i] = standardNormalDistribution.InverseCDF(inputNonexceedanceProbabilities[i]);
+                inputZs[i] = standardNormalDistribution.InverseCDF(1-inputExceedanceProbabilities[i]);
             }
             double[] neededZs = new double[exceedanceProbabilitiesForWhichQuantilesAreRequired.Length];
             for (int i = 0; i < exceedanceProbabilitiesForWhichQuantilesAreRequired.Length; i++)
             {
                 neededZs[i] = standardNormalDistribution.InverseCDF(1-exceedanceProbabilitiesForWhichQuantilesAreRequired[i]);
             }
-
+            //could there be a problem here with expecting non exceedance but having exceedance? I don't think so 
             IPairedData nonexceedance_zScore = new PairedData(exceedanceProbabilitiesForWhichQuantilesAreRequired, neededZs);
             IPairedData zScore_stage_flow = new PairedData(inputZs, inputDataForInterpolation);
             IPairedData interpolatedFrequencyCurve = zScore_stage_flow.compose(nonexceedance_zScore);

--- a/HEC.FDA.Model/paireddata/PairedData.cs
+++ b/HEC.FDA.Model/paireddata/PairedData.cs
@@ -366,7 +366,31 @@ namespace HEC.FDA.Model.paireddata
             }
             Yvals = update;
         }
-        public void ForceStrictMonotonicity(double max = double.MaxValue, double min = double.MinValue)
+        public void ForceStrictMonotonicityTopDown(double max = double.MaxValue, double min = double.MinValue)
+        {
+            double epsilon = 0.005;
+
+            double[] update = new double[Yvals.Length];
+            double upperValue = Yvals[Yvals.Length - 1];
+            update[Yvals.Length - 1] = upperValue;
+
+            for (int i = Yvals.Length - 2; i >= 0; i--)
+            {
+
+                if (Yvals[i] >= upperValue)
+                {
+                    update[i] = upperValue - epsilon;
+                    upperValue -= epsilon;
+                }
+                else
+                {
+                    update[i] = Yvals[i];
+                    upperValue = Yvals[i];
+                }
+            }
+            Yvals = update;
+        }
+        public void ForceStrictMonotonicityBottomUp(double max = double.MaxValue, double min = double.MinValue)
         {
             double epsilon = 0.005;
             double previousYval = min;
@@ -398,7 +422,6 @@ namespace HEC.FDA.Model.paireddata
             }
             Yvals = update;
         }
-
         public void SortToIncreasingXVals()
         {
             Array.Sort(Xvals,Yvals);

--- a/HEC.FDA.Model/paireddata/PairedData.cs
+++ b/HEC.FDA.Model/paireddata/PairedData.cs
@@ -9,6 +9,7 @@ namespace HEC.FDA.Model.paireddata
     public class PairedData : IPairedData
     {
         #region Fields 
+        private const double EPSILON = double.Epsilon;
         #endregion
 
         #region Properties 
@@ -368,8 +369,6 @@ namespace HEC.FDA.Model.paireddata
         }
         public void ForceStrictMonotonicityTopDown(double max = double.MaxValue, double min = double.MinValue)
         {
-            double epsilon = 0.005;
-
             double[] update = new double[Yvals.Length];
             double upperValue = Yvals[Yvals.Length - 1];
             update[Yvals.Length - 1] = upperValue;
@@ -379,8 +378,8 @@ namespace HEC.FDA.Model.paireddata
 
                 if (Yvals[i] >= upperValue)
                 {
-                    update[i] = upperValue - epsilon;
-                    upperValue -= epsilon;
+                    update[i] = upperValue - EPSILON;
+                    upperValue -= EPSILON;
                 }
                 else
                 {
@@ -392,7 +391,6 @@ namespace HEC.FDA.Model.paireddata
         }
         public void ForceStrictMonotonicityBottomUp(double max = double.MaxValue, double min = double.MinValue)
         {
-            double epsilon = 0.005;
             double previousYval = min;
 
             double[] update = new double[Yvals.Length];
@@ -401,8 +399,8 @@ namespace HEC.FDA.Model.paireddata
             {
                 if (previousYval >= currentY)
                 {
-                    update[index] = previousYval + epsilon;
-                    previousYval += epsilon;
+                    update[index] = previousYval + EPSILON;
+                    previousYval += EPSILON;
                 }
                 else
                 {

--- a/HEC.FDA.ModelTest/unittests/GraphicalUncertaintyPairedDataTests.cs
+++ b/HEC.FDA.ModelTest/unittests/GraphicalUncertaintyPairedDataTests.cs
@@ -108,7 +108,7 @@ new double[] { 6.6, 7.4, 8.55, 9.95, 11.5, 12.7, 13.85, 14.7, 15.8, 16.7, 17.5, 
                 double probability = probabilitiesAtWhichToTest[i];
                 double actual = oneStandardDeviationAboveMean.f(probability);
                 double expected = expectedQuantile[i];
-                Assert.Equal(expected, actual, 0.18);
+                Assert.Equal(expected, actual, 0.01);
             }
 
 

--- a/HEC.FDA.ModelTest/unittests/GraphicalUncertaintyPairedDataTests.cs
+++ b/HEC.FDA.ModelTest/unittests/GraphicalUncertaintyPairedDataTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 using System.Xml.Linq;
 using HEC.FDA.Model.paireddata;
 using Statistics.Distributions;
-using Statistics.GraphicalRelationships;
+using HEC.FDA.Model.extensions;
 using System;
 
 namespace HEC.FDA.ModelTest.unittests

--- a/HEC.FDA.ModelTest/unittests/GraphicalUncertaintyPairedDataTests.cs
+++ b/HEC.FDA.ModelTest/unittests/GraphicalUncertaintyPairedDataTests.cs
@@ -88,18 +88,18 @@ new double[] { 6.6, 7.4, 8.55, 9.95, 11.5, 12.7, 13.85, 14.7, 15.8, 16.7, 17.5, 
         }
 
         /// <summary>
-        /// This test demonstrates that our quantile interpolation reasonably matches direct quantile calculation
-        /// test data can be found at: https://docs.google.com/spreadsheets/d/1aLnGuzmmopDID7ehb1Jux5IZtegMpmnX/edit?usp=drive_link&ouid=105470256128470573157&rtpof=true&sd=true
+        /// This test demonstrates that our quantile sampling reasonably matches direct quantile calculation
+        /// test data for the first case study can be found at: https://docs.google.com/spreadsheets/d/1aLnGuzmmopDID7ehb1Jux5IZtegMpmnX/edit?usp=drive_link&ouid=105470256128470573157&rtpof=true&sd=true
+        /// test data for the second case study was generated from HEC-FDA Version 1.4.3 from the Algiers feasibilty study data 
         /// </summary>
         /// <param name="probabilitiesAtWhichToTest"></param> these are probabilities for quantiles that are interpolated
         /// <param name="expectedQuantile"></param> these are interpolated quantiles 
         [Theory]
-        [InlineData(new double[] {0.35, 0.75, 0.956, 0.9905}, new double[] {81.8684, 84.060773, 84.970707, 88.707344})]
-        public void SamplePairedDataShould(double[] probabilitiesAtWhichToTest, double[] expectedQuantile)
+        [InlineData(new double[] { 0.999, 0.5, 0.2, 0.1, 0.04, 0.02, 0.01, 0.004, 0.002 }, new double[] { 80, 82, 84, 84.5, 84.8, 85, 86, 88, 90 }, 50, 1, new double[] {0.35, 0.75, 0.956, 0.9905}, new double[] {81.8684, 84.060773, 84.970707, 88.707344})]
+        [InlineData(new double[] {0.5,0.2, 0.1, 0.04, 0.02, 0.01, 0.005, 0.002}, new double[] {1, 1.1, 4.93, 4.98, 5.02, 5.04, 5.18, 5.3}, 40, 2, new double[] { .1, .78, .8, .825, .99, .995 }, new double[] {1, 1.144, 3.398, 4.995, 5.216, 5.356})]
+        public void SamplePairedDataShould(double[] inputProbabilities, double[] inputStages, int erl, int standardDeviationAtWhichToTest, double[] probabilitiesAtWhichToTest, double[] expectedQuantile)
         {
-            int erl = 50;
-            double[] inputProbabilities = new double[] { 0.999, 0.5, 0.2, 0.1, 0.04, 0.02, 0.01, 0.004, 0.002 };
-            double[] inputStages = new double[] { 80, 82, 84, 84.5, 84.8, 85, 86, 88, 90 };
+
             GraphicalUncertainPairedData graphicalUncertainPairedData = new(inputProbabilities, inputStages, erl, new CurveMetaData("hello"), true);
             double probOneStandardDeviation = new Normal().CDF(1);
             PairedData oneStandardDeviationAboveMean = graphicalUncertainPairedData.SamplePairedData(probOneStandardDeviation);

--- a/HEC.FDA.ModelTest/unittests/extensions/GraphicalTests.cs
+++ b/HEC.FDA.ModelTest/unittests/extensions/GraphicalTests.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using Xunit;
-using Statistics.GraphicalRelationships;
+using HEC.FDA.Model.extensions;
 using Statistics.Distributions;
+using HEC.FDA.ModelTest.unittests.extensions;
 
-namespace StatisticsTests.GraphicalRelationships
+namespace HEC.FDA.ModelTest.unittests.extensions
 {
     [Trait("RunsOn", "Remote")]
     public class GraphicalTests
@@ -58,8 +59,8 @@ namespace StatisticsTests.GraphicalRelationships
         /// Test data: https://docs.google.com/spreadsheets/d/1GhRe3ECAFIKgRqEE8Xo6f_0lHYnHqUW0/edit?usp=sharing&ouid=105470256128470573157&rtpof=true&sd=true
         /// </summary>
         [Theory]
-        [InlineData(new double[] { 0.999, 0.5, 0.2, 0.1, 0.02, 0.01, 0.005, 0.001, 0.0001 }, new double[] { 80, 11320, 18520, 23810, 35010, 39350, 42850, 47300, 52739.48924 }, 50, true, new double[] { 936.69, 1951.72, 3213.97, 6066.15, 7900.75, 7900.75} )]
-        [InlineData(new double[] { 0.999, 0.5, 0.2, 0.1, 0.02, 0.01, 0.005, 0.001, 0.0001 }, new double[] { 80, 11320, 18520, 23810, 35010, 39350, 42850, 47300, 52739.48924 }, 50, false, new double[] {.2244,  .1164, .1293, .1924, .2030, .2030})]
+        [InlineData(new double[] { 0.999, 0.5, 0.2, 0.1, 0.02, 0.01, 0.005, 0.001, 0.0001 }, new double[] { 80, 11320, 18520, 23810, 35010, 39350, 42850, 47300, 52739.48924 }, 50, true, new double[] { 936.69, 1951.72, 3213.97, 6066.15, 7900.75, 7900.75 })]
+        [InlineData(new double[] { 0.999, 0.5, 0.2, 0.1, 0.02, 0.01, 0.005, 0.001, 0.0001 }, new double[] { 80, 11320, 18520, 23810, 35010, 39350, 42850, 47300, 52739.48924 }, 50, false, new double[] { .2244, .1164, .1293, .1924, .2030, .2030 })]
         public void ReturnsCorrectStandardDeviations(double[] exceedanceProbabilities, double[] flowOrStageValues, int equivalentRecordLength, bool usingStagesNotFlows, double[] expectedSD)
         {
             GraphicalDistribution graphical = new GraphicalDistribution(exceedanceProbabilities, flowOrStageValues, equivalentRecordLength, usingStagesNotFlows);
@@ -78,14 +79,14 @@ namespace StatisticsTests.GraphicalRelationships
                 //TODO: The values used to calculate the test data were calculated with a different slope schema than the one that has been implemented, which is better. 
                 //Re-do the test data to update to current methodology 
                 double tolerance = 0.15;
-                double relativeError = Math.Abs((actual - expectedSD[i-2]) / expectedSD[i-2]);
+                double relativeError = Math.Abs((actual - expectedSD[i - 2]) / expectedSD[i - 2]);
                 Assert.True(relativeError < tolerance);
             }
         }
 
         [Theory]
-        [InlineData(0.25, 1/0.1797, 50, 0.3408)]
-        [InlineData(0.963, 1/0.0017, 50, 15.3195)]
+        [InlineData(0.25, 1 / 0.1797, 50, 0.3408)]
+        [InlineData(0.963, 1 / 0.0017, 50, 15.3195)]
         public void Equation6Should(double nonExceedanceProbability, double slope, int erl, double expected)
         {
             double actual = GraphicalDistribution.Equation6StandardError(nonExceedanceProbability, slope, erl);
@@ -93,21 +94,21 @@ namespace StatisticsTests.GraphicalRelationships
         }
 
         [Theory]
-        [InlineData(0.999,0.99,900,800,0.995,832.6595)]
-        [InlineData(0.34,0.31,1002,1000,0.32,1000.6752)]
-        [InlineData(0.004,0.002,1200,1100, 0.0025, 1131.4598)]
-        public void InterpolateNormallyShould(double p, double p_minus, double q, double q_minus, double p_minusEpsilon,  double expected)
+        [InlineData(0.999, 0.99, 900, 800, 0.995, 832.6595)]
+        [InlineData(0.34, 0.31, 1002, 1000, 0.32, 1000.6752)]
+        [InlineData(0.004, 0.002, 1200, 1100, 0.0025, 1131.4598)]
+        public void InterpolateNormallyShould(double p, double p_minus, double q, double q_minus, double p_minusEpsilon, double expected)
         {
-            double actual = GraphicalDistribution.InterpolateNormally(p, p_minus, q, q_minus, p_minusEpsilon); 
+            double actual = GraphicalDistribution.InterpolateNormally(p, p_minus, q, q_minus, p_minusEpsilon);
             Assert.Equal(expected, actual, 0.01);
         }
 
         [Theory]
-        [InlineData(new double[] {0.5, 0.2, 0.1}, new double[] {102, 104, 104.2}, 1, 5.0560)]
-        [InlineData(new double[] {0.99, 0.5, 0.2}, new double[] {101.5, 102, 104}, 1, 3.2477)]
+        [InlineData(new double[] { 0.5, 0.2, 0.1 }, new double[] { 102, 104, 104.2 }, 1, 5.0560)]
+        [InlineData(new double[] { 0.99, 0.5, 0.2 }, new double[] { 101.5, 102, 104 }, 1, 3.2477)]
         public void ComputeSlopeShould(double[] exceedanceProbabilities, double[] stageOrLoggedFlowValues, int index, double expected)
         {
-            double actual = GraphicalDistribution.ComputeSlope(exceedanceProbabilities,stageOrLoggedFlowValues,index);
+            double actual = GraphicalDistribution.ComputeSlope(exceedanceProbabilities, stageOrLoggedFlowValues, index);
             Assert.Equal(expected, actual, 0.5);
         }
     }


### PR DESCRIPTION
I have redesigned the computational algorithm for generating uncertainty about graphical frequency curves and have added a unit test for the edge case (provided by the Algiers PDT) that illuminated the need for the change. HEC-FDA Version 2.0 is now producing nearly exactly the same uncertainty as HEC-FDA Version 1.4.3 for this edge case. 