### PR TITLE
Fix bug in CSVRs where central tendencies and std.dev were swapped

### DIFF
--- a/HEC.FDA.Importer/AsciiImportExport/AsciiImport.cs
+++ b/HEC.FDA.Importer/AsciiImportExport/AsciiImport.cs
@@ -897,11 +897,11 @@ namespace Importer
                     case 8:     //Distribution type
                         _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.CONTENT).SetErrorType(fieldCap);
                         break;
-                    case 9:     //Content to structure value ratio 
-                        _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.CONTENT).StandardDeviationOrMin = (Convert.ToDouble(fieldCap));
+                    case 9:     //Content to structure value ratio  
+                        _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.CONTENT).CentralValue = (Convert.ToDouble(fieldCap));
                         break;
                     case 10:    //Std. Dev for N or L, Lower for T Should probably be Central Value
-                        _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.CONTENT).CentralValue = (Convert.ToDouble(fieldCap));
+                        _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.CONTENT).StandardDeviationOrMin = (Convert.ToDouble(fieldCap));
                         break;
                     case 11:    //Upper for T
                         _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.CONTENT).Maximum = (Convert.ToDouble(fieldCap));
@@ -911,10 +911,10 @@ namespace Importer
                         _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.OTHER).SetErrorType(fieldCap);
                         break;
                     case 13:    //Other to structure value ratio 
-                        _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.OTHER).StandardDeviationOrMin = (Convert.ToDouble(fieldCap));
+                        _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.OTHER).CentralValue = (Convert.ToDouble(fieldCap));
                         break;
                     case 14:    //Std. Dev for N or L, Lower for T
-                        _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.OTHER).CentralValue = (Convert.ToDouble(fieldCap));
+                        _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.OTHER).StandardDeviationOrMin = (Convert.ToDouble(fieldCap));
                         break;
                     case 15:    //Upper for T
                         _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.OTHER).Maximum = (Convert.ToDouble(fieldCap));
@@ -924,10 +924,10 @@ namespace Importer
                         _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.AUTO).SetErrorType(fieldCap);
                         break;
                     case 17:    //Automobile to structure value ratio
-                        _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.AUTO).StandardDeviationOrMin = (Convert.ToDouble(fieldCap));
+                        _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.AUTO).CentralValue = (Convert.ToDouble(fieldCap));
                         break;
                     case 18:    //Std. Dev for N or L, Lower for T
-                        _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.AUTO).CentralValue = (Convert.ToDouble(fieldCap));
+                        _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.AUTO).StandardDeviationOrMin = (Convert.ToDouble(fieldCap));
                         break;
                     case 19:    //Upper for T
                         _OccupancyType.GetErrorDistribution(OccTypeStrucComponent.AUTO).Maximum = (Convert.ToDouble(fieldCap));

--- a/HEC.FDA.ViewModel/Utilities/ImportFromFDA1Helper.cs
+++ b/HEC.FDA.ViewModel/Utilities/ImportFromFDA1Helper.cs
@@ -715,6 +715,15 @@ namespace HEC.FDA.ViewModel.Utilities
                     double newLogStDev = logMean * logStDev / 100;
                     retval = new LogNormal(logMean, newLogStDev);
                     break;
+                case IDistributionEnum.Triangular:
+                    Triangular triDist = dist as Triangular;
+                    double mostLikely = triDist.MostLikely;
+                    double min = triDist.Min;
+                    double max = triDist.Max;
+                    double newMin = mostLikely * min / 100;
+                    double newMax = mostLikely * max / 100;
+                    retval = new Triangular(newMin, mostLikely, newMax);                  
+                    break;
             }
             return retval;
         }

--- a/HEC.FDA.ViewModel/Utilities/ImportFromFDA1Helper.cs
+++ b/HEC.FDA.ViewModel/Utilities/ImportFromFDA1Helper.cs
@@ -694,6 +694,10 @@ namespace HEC.FDA.ViewModel.Utilities
             return ot;
         }
 
+        /// <summary>
+        /// 1.4.x specified distributions with coefficient of variance instead of standard deviation, and specified min and max for triangular as percentages of the mean. 
+        /// This method converts that to the 2.0 standard. 
+        /// </summary>
         private static ContinuousDistribution ConvertRatioValueToFDA2(ContinuousDistribution dist)
         {
             ContinuousDistribution retval = dist;
@@ -728,6 +732,9 @@ namespace HEC.FDA.ViewModel.Utilities
             return retval;
         }
 
+        /// <summary>
+        /// This translates error distributions for assets whos' central tendency is described in the structure inventory. Most likely value is set to 100, which indicates 100% of the inventory value. 
+        /// </summary>
         private static ContinuousDistribution TranslateStructureValueUncertainty(ErrorDistribution errorDist)
         {
             //It looks like the only options that will actually come in here is Normal, Triangular, Log Normal.
@@ -763,7 +770,7 @@ namespace HEC.FDA.ViewModel.Utilities
             //It looks like the only options that will actually come in here is Normal, Triangular, Log Normal.
             double mean = errorDist.CentralValue;
             //st dev gets reused as min
-            double stDev = errorDist.StandardDeviationOrMin;
+            double stDevOrMin = errorDist.StandardDeviationOrMin;
             double max = errorDist.Maximum;
             ErrorType type = errorDist.ErrorType;
             ContinuousDistribution dist = new Deterministic(mean);
@@ -772,17 +779,20 @@ namespace HEC.FDA.ViewModel.Utilities
                 case ErrorType.NONE:
                     dist = new Deterministic(mean);
                     break;
+                    //ErrorDistribution actually specifies the Coefficient of Variance, so this is a dirty object that will need to be processed later.  
                 case ErrorType.NORMAL:
-                    dist = new Normal(mean, stDev);
+                    dist = new Normal(mean, stDevOrMin);
                     break;
+                    //Error Distribution specifies min and max as percentages of the mean, so this is another dirty object. 
                 case ErrorType.TRIANGULAR:
-                    dist = new Triangular(stDev, mean, max);
+                    dist = new Triangular(stDevOrMin, mean, max);
                     break;
                 case ErrorType.UNIFORM:
                     dist = new Uniform(mean, max);
                     break;
+                //ErrorDistribution actually specifies the Coefficient of Variance, so this is a dirty object that will need to be processed later.  
                 case ErrorType.LOGNORMAL:
-                    dist = new LogNormal(mean, stDev);
+                    dist = new LogNormal(mean, stDevOrMin);
                     break;
             }
             return dist;


### PR DESCRIPTION
Fixes bug where triangular inputs were not being properly translated from 1.4.x formats and mean and standard deviation were  being swapped for normal dists. 