### PR TITLE
Fixes #1265 with validation added to AEP with Given Assurance Method

### DIFF
--- a/HEC.FDA.Model/metrics/SystemPerformanceResults.cs
+++ b/HEC.FDA.Model/metrics/SystemPerformanceResults.cs
@@ -137,6 +137,19 @@ namespace HEC.FDA.Model.metrics
         internal double AEPWithGivenAssurance(double assurance)
         {
             double aepWithGivenAssurance = GetAssurance(AEP_ASSURANCE_TYPE).AssuranceHistogram.InverseCDF(assurance);
+
+            //AEP with given assurance can come back slightly higher than 1
+            //for histograms where the vast majority of AEPs are near 0.9999
+            //not a situation where AEPs are actually greater than 1
+            //this validation corrects for that histogram binning imperfection
+            //for the specific purpose of assurance of AEP
+            //in the edge case where the majority of AEPs are near 0.9999
+            //occurs where threshold stage is really low relative to stage-frequency function 
+            if (aepWithGivenAssurance > 1)
+            {
+                aepWithGivenAssurance = 1;
+            }
+
             return aepWithGivenAssurance;
         }
 


### PR DESCRIPTION
@Brennan1994 this fix is ready for your review. 

This fix does not attempt to improve histogram binning, which is a complex effort left to a later date, probably part of our R&D work unit when we look at empirical hazard uncertainty. 

For now, I added validation where this specific issue will come up. 

I look forward to your thoughts. 